### PR TITLE
Improve OpenAI image streaming fallback and canvas connection controls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ backend/ccode-images/
 .trae/
 .codex/
 .agents/
+/docs/
 
 data/
 # Docker Compose 运行时在根目录复制的配置（勿提交）

--- a/backend/server.js
+++ b/backend/server.js
@@ -108,7 +108,9 @@ const DB_PATH = process.env.NOVA_TASK_DB || path.join(__dirname, 'nova-tasks.sql
 const TASK_TTL_MS = 12 * 60 * 60 * 1000;
 const CLEANUP_INTERVAL_MS = 5 * 60 * 1000;
 const REQUEST_TIMEOUT_MS = 30 * 60 * 1000; // 30 minutes
-const IMAGE_STREAM_UNSUPPORTED_PATTERN = /(?:stream.*(?:unsupported|not supported|unknown|unrecognized|invalid)|(?:unsupported|not supported|unknown|unrecognized|invalid).*stream|stream.*(?:不支持|未知|无效)|(?:不支持|未知|无效).*stream)/i;
+const IMAGE_STREAM_ENABLED = String(process.env.NOVA_IMAGE_STREAM ?? 'true').toLowerCase() !== 'false';
+const IMAGE_STREAM_PARTIAL_IMAGES = Math.min(3, Math.max(0, Number.parseInt(process.env.NOVA_IMAGE_PARTIAL_IMAGES || '1', 10) || 1));
+const IMAGE_STREAM_UNSUPPORTED_PATTERN = /(?:(?:stream|partial_images).*(?:unsupported|not supported|unknown|unrecognized|invalid)|(?:unsupported|not supported|unknown|unrecognized|invalid).*(?:stream|partial_images)|(?:stream|partial_images).*(?:不支持|未知|无效)|(?:不支持|未知|无效).*(?:stream|partial_images))/i;
 // 开源版：不再硬编码模型列表，由前端通过 protocol 字段指定协议类型
 const VALID_PROTOCOLS = new Set(['google', 'openai', 'grok']);
 const GPT_IMAGE_QUALITIES = new Set(['auto', 'high', 'medium', 'low']);
@@ -801,6 +803,7 @@ function createGptImageRequestInit(apiKey, request, resolvedSize, options = {}) 
   const prompt = request.prompt;
   const advancedParams = getGptImageRequestAdvancedParams(request);
   const stream = Boolean(options.stream);
+  const partialImages = Math.min(3, Math.max(0, Number(options.partialImages) || 0));
 
   if (request.mode === 'image-to-image') {
     const formData = new FormData();
@@ -809,6 +812,7 @@ function createGptImageRequestInit(apiKey, request, resolvedSize, options = {}) 
     formData.append('n', '1');
     if (stream) {
       formData.append('stream', 'true');
+      if (partialImages > 0) formData.append('partial_images', String(partialImages));
     }
     if (advancedParams) {
       formData.append('quality', advancedParams.quality);
@@ -842,7 +846,7 @@ function createGptImageRequestInit(apiKey, request, resolvedSize, options = {}) 
   const payload = {
     prompt,
     model: request.model,
-    ...(stream ? { stream: true } : {}),
+    ...(stream ? { stream: true, ...(partialImages > 0 ? { partial_images: partialImages } : {}) } : {}),
     ...(resolvedSize ? { size: resolvedSize } : {}),
     ...(advancedParams ? {
       quality: advancedParams.quality,
@@ -1171,7 +1175,21 @@ async function generateNovaImage(apiKey, request) {
   // 开源版：根据前端传入的 protocol 字段路由到对应的 API 协议
   const baseUrl = request.baseUrl || resolveNovaApiBaseUrl();
   if (request.protocol === 'openai') {
-    return requestGptImage(apiKey, request, resolveGptImageRequestSize(request), { baseUrl });
+    const resolvedSize = resolveGptImageRequestSize(request);
+    if (!IMAGE_STREAM_ENABLED) {
+      return requestGptImage(apiKey, request, resolvedSize, { baseUrl });
+    }
+    try {
+      return await requestGptImage(apiKey, request, resolvedSize, {
+        baseUrl,
+        stream: true,
+        partialImages: IMAGE_STREAM_PARTIAL_IMAGES,
+      });
+    } catch (error) {
+      if (!isImageStreamUnsupportedError(error)) throw error;
+      console.warn('[image-stream] 上游不支持图片流式参数，回退非流式请求');
+      return requestGptImage(apiKey, request, resolvedSize, { baseUrl });
+    }
   }
   if (request.protocol === 'grok') {
     return requestGrokImage(apiKey, request, { baseUrl });

--- a/backend/test/image-stream.integration.test.js
+++ b/backend/test/image-stream.integration.test.js
@@ -1,0 +1,136 @@
+const assert = require('node:assert/strict');
+const { spawn } = require('node:child_process');
+const fs = require('node:fs');
+const http = require('node:http');
+const os = require('node:os');
+const path = require('node:path');
+const test = require('node:test');
+
+const BACKEND_DIR = path.resolve(__dirname, '..');
+
+function listen(server) {
+  return new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => resolve(server.address().port));
+  });
+}
+
+function close(server) {
+  server.closeAllConnections?.();
+  return new Promise(resolve => server.close(resolve));
+}
+
+async function waitFor(predicate, timeoutMs = 10000) {
+  const deadline = Date.now() + timeoutMs;
+  let lastError;
+  while (Date.now() < deadline) {
+    try {
+      const value = await predicate();
+      if (value) return value;
+    } catch (error) {
+      lastError = error;
+    }
+    await new Promise(resolve => setTimeout(resolve, 50));
+  }
+  throw lastError || new Error('Timed out waiting for condition');
+}
+
+async function stopBackend(child) {
+  if (child.exitCode !== null) return;
+  child.kill('SIGTERM');
+  const stopped = await Promise.race([
+    new Promise(resolve => child.once('exit', () => resolve(true))),
+    new Promise(resolve => setTimeout(() => resolve(false), 3000)),
+  ]);
+  if (!stopped && child.exitCode === null) {
+    child.kill('SIGKILL');
+    await new Promise(resolve => child.once('exit', resolve));
+  }
+}
+
+test('retries an unsupported partial-images request without stream parameters', async t => {
+  const upstreamRequests = [];
+  const upstream = http.createServer(async (req, res) => {
+    const chunks = [];
+    for await (const chunk of req) chunks.push(chunk);
+    const body = JSON.parse(Buffer.concat(chunks).toString('utf8'));
+    upstreamRequests.push(body);
+
+    if (body.stream) {
+      res.writeHead(400, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: { message: 'Unsupported parameter: partial_images' } }));
+      return;
+    }
+
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ data: [{ b64_json: Buffer.from('image').toString('base64') }] }));
+  });
+  const upstreamPort = await listen(upstream);
+
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'nova-image-stream-'));
+
+  const portProbe = http.createServer();
+  const backendPort = await listen(portProbe);
+  await close(portProbe);
+
+  const child = spawn(process.execPath, ['server.js'], {
+    cwd: BACKEND_DIR,
+    env: {
+      ...process.env,
+      NODE_ENV: 'production',
+      HOSTNAME: '127.0.0.1',
+      PORT: String(backendPort),
+      NOVA_TASK_DB: path.join(tempDir, 'tasks.sqlite'),
+      NOVA_IMAGE_DIR: path.join(tempDir, 'images'),
+      NOVA_IMAGE_PARTIAL_IMAGES: '2',
+    },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  let backendOutput = '';
+  child.stdout.on('data', chunk => { backendOutput += chunk; });
+  child.stderr.on('data', chunk => { backendOutput += chunk; });
+  t.after(async () => {
+    await stopBackend(child);
+    await close(upstream);
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  const backendUrl = `http://127.0.0.1:${backendPort}`;
+  await waitFor(async () => {
+    if (child.exitCode !== null) throw new Error(`Backend exited early:\n${backendOutput}`);
+    const response = await fetch(`${backendUrl}/api/nova/queue-status`);
+    return response.ok;
+  });
+
+  const createResponse = await fetch(`${backendUrl}/api/nova/tasks`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      apiKey: 'test-key',
+      baseUrl: `http://127.0.0.1:${upstreamPort}`,
+      protocol: 'openai',
+      mode: 'text-to-image',
+      prompt: 'test image',
+      model: 'gpt-image-1',
+      parallelCount: 1,
+      outputSize: 'auto',
+      aspectRatio: 'auto',
+      images: [],
+    }),
+  });
+  assert.equal(createResponse.status, 202);
+  const { taskId } = await createResponse.json();
+
+  const task = await waitFor(async () => {
+    const response = await fetch(`${backendUrl}/api/nova/tasks/${taskId}`);
+    const value = await response.json();
+    return ['completed', 'failed'].includes(value.status) ? value : null;
+  });
+
+  assert.equal(task.status, 'completed', backendOutput);
+  assert.equal(upstreamRequests.length, 2);
+  assert.equal(upstreamRequests[0].stream, true);
+  assert.equal(upstreamRequests[0].partial_images, 2);
+  assert.equal('stream' in upstreamRequests[1], false);
+  assert.equal('partial_images' in upstreamRequests[1], false);
+});

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "3.1.3",
       "dependencies": {
         "@base-ui/react": "^1.3.0",
+        "@dagrejs/dagre": "^3.0.0",
         "@radix-ui/react-popover": "^1.1.15",
         "@radix-ui/react-slider": "^1.3.6",
         "@tanstack/react-virtual": "^3.13.23",
@@ -1906,6 +1907,21 @@
       "engines": {
         "node": ">=20.19.0"
       }
+    },
+    "node_modules/@dagrejs/dagre": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmmirror.com/@dagrejs/dagre/-/dagre-3.0.0.tgz",
+      "integrity": "sha512-ZzhnTy1rfuoew9Ez3EIw4L2znPGnYYhfn8vc9c4oB8iw6QAsszbiU0vRhlxWPFnmmNSFAkrYeF1PhM5m4lAN0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@dagrejs/graphlib": "4.0.1"
+      }
+    },
+    "node_modules/@dagrejs/graphlib": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmmirror.com/@dagrejs/graphlib/-/graphlib-4.0.1.tgz",
+      "integrity": "sha512-IvcV6FduIIAmLwnH+yun+QtV36SC7mERqa86aClNqmMN09WhmPPYU8ckHrZBozErf+UvHPWOTJYaGYiIcs0DgA==",
+      "license": "MIT"
     },
     "node_modules/@dotenvx/dotenvx": {
       "version": "1.69.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@base-ui/react": "^1.3.0",
+    "@dagrejs/dagre": "^3.0.0",
     "@radix-ui/react-popover": "^1.1.15",
     "@radix-ui/react-slider": "^1.3.6",
     "@tanstack/react-virtual": "^3.13.23",

--- a/frontend/src/components/__tests__/TextToImageForm.test.tsx
+++ b/frontend/src/components/__tests__/TextToImageForm.test.tsx
@@ -1,30 +1,77 @@
+import type { ComponentProps } from 'react'
 import { beforeEach, describe, it, expect, vi } from 'vitest'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { act, render, screen, fireEvent } from '@testing-library/react'
 import { TextToImageForm } from '../TextToImageForm'
+import { syncDynamicModelExports } from '@/lib/gemini-config'
+import { saveRegistry } from '@/lib/nova-models'
+
+async function renderForm(props: ComponentProps<typeof TextToImageForm>) {
+  const result = render(<TextToImageForm {...props} />)
+  await act(async () => {})
+  return result
+}
 
 describe('TextToImageForm', () => {
   beforeEach(() => {
     localStorage.clear()
+    saveRegistry({
+      imageModels: [
+        {
+          id: 'gemini-3-pro-image-preview',
+          protocol: 'google',
+          name: 'Banana Pro',
+          modelId: 'gemini-3-pro-image-preview',
+          apiKey: 'test-google-key',
+          baseUrl: 'https://generativelanguage.googleapis.com',
+          builtinPreset: 'gemini-3-pro-image-preview',
+          maxRefImages: 14,
+          maxOutputSize: '4K',
+          supportsAdvancedParams: false,
+        },
+        {
+          id: 'gpt-image-2',
+          protocol: 'openai',
+          name: 'GPT Image 2',
+          modelId: 'gpt-image-2',
+          apiKey: 'test-openai-key',
+          baseUrl: 'https://api.openai.com',
+          builtinPreset: 'gpt-image-2',
+          maxRefImages: 16,
+          maxOutputSize: '4K',
+          supportsAdvancedParams: true,
+        },
+      ],
+      textModels: [],
+      defaults: {
+        textToImage: 'gemini-3-pro-image-preview',
+        imageToImage: 'gemini-3-pro-image-preview',
+        reversePrompt: '',
+        agent: '',
+        promptOptimize: '',
+        imageDescribe: '',
+      },
+    })
+    syncDynamicModelExports()
   })
 
-  it('renders the form with placeholder text', () => {
+  it('renders the form with placeholder text', async () => {
     const onSubmit = vi.fn()
-    render(<TextToImageForm onSubmit={onSubmit} />)
+    await renderForm({ onSubmit })
 
     expect(screen.getByPlaceholderText('描述你想要生成的图像...')).toBeInTheDocument()
   })
 
-  it('submit button is disabled when prompt is empty', () => {
+  it('submit button is disabled when prompt is empty', async () => {
     const onSubmit = vi.fn()
-    render(<TextToImageForm onSubmit={onSubmit} />)
+    await renderForm({ onSubmit })
 
     const submitButton = screen.getByRole('button', { name: '' }) // Arrow icon button
     expect(submitButton).toBeDisabled()
   })
 
-  it('submit button is enabled when prompt has text', () => {
+  it('submit button is enabled when prompt has text', async () => {
     const onSubmit = vi.fn()
-    render(<TextToImageForm onSubmit={onSubmit} />)
+    await renderForm({ onSubmit })
 
     const textarea = screen.getByPlaceholderText('描述你想要生成的图像...')
     fireEvent.change(textarea, { target: { value: 'A beautiful sunset' } })
@@ -33,9 +80,9 @@ describe('TextToImageForm', () => {
     expect(submitButton).not.toBeDisabled()
   })
 
-  it('calls onSubmit with prompt when Shift+Enter is pressed', () => {
+  it('calls onSubmit with prompt when Shift+Enter is pressed', async () => {
     const onSubmit = vi.fn()
-    render(<TextToImageForm onSubmit={onSubmit} />)
+    await renderForm({ onSubmit })
 
     const textarea = screen.getByPlaceholderText('描述你想要生成的图像...')
     fireEvent.change(textarea, { target: { value: 'A beautiful sunset' } })
@@ -56,19 +103,17 @@ describe('TextToImageForm', () => {
 
   it('shows image params control for GPT Image 2 model', async () => {
     const onSubmit = vi.fn()
-    render(<TextToImageForm onSubmit={onSubmit} initialData={{ model: 'gpt-image-2' }} />)
+    await renderForm({ onSubmit, initialData: { model: 'gpt-image-2' } })
 
     expect(await screen.findByTitle('图像参数')).toBeInTheDocument()
   })
 
   it('submits default image params for GPT Image 2 model when left on auto', async () => {
     const onSubmit = vi.fn()
-    render(
-      <TextToImageForm
-        onSubmit={onSubmit}
-        initialData={{ model: 'gpt-image-2', prompt: 'Cut out the subject' }}
-      />
-    )
+    await renderForm({
+      onSubmit,
+      initialData: { model: 'gpt-image-2', prompt: 'Cut out the subject' },
+    })
 
     const textarea = screen.getByPlaceholderText('描述你想要生成的图像...')
     await screen.findByTitle('图像参数')
@@ -82,9 +127,9 @@ describe('TextToImageForm', () => {
     }))
   })
 
-  it('does NOT submit when plain Enter is pressed', () => {
+  it('does NOT submit when plain Enter is pressed', async () => {
     const onSubmit = vi.fn()
-    render(<TextToImageForm onSubmit={onSubmit} />)
+    await renderForm({ onSubmit })
 
     const textarea = screen.getByPlaceholderText('描述你想要生成的图像...')
     fireEvent.change(textarea, { target: { value: 'A beautiful sunset' } })
@@ -93,9 +138,9 @@ describe('TextToImageForm', () => {
     expect(onSubmit).not.toHaveBeenCalled()
   })
 
-  it('shows configuration prompt when disabled prop is true', () => {
+  it('shows configuration prompt when disabled prop is true', async () => {
     const onSubmit = vi.fn()
-    render(<TextToImageForm onSubmit={onSubmit} disabled />)
+    await renderForm({ onSubmit, disabled: true })
 
     expect(screen.getByText('API 密钥未配置')).toBeInTheDocument()
     expect(screen.getByRole('button', { name: '配置' })).toBeInTheDocument()

--- a/frontend/src/components/canvas/CanvasEditor.tsx
+++ b/frontend/src/components/canvas/CanvasEditor.tsx
@@ -41,7 +41,7 @@ import {
   MANUAL_PROMPT_ROUTE_VALUE,
 } from "./lib/canvas-prompt-routes";
 import { compressReferenceDataUrl, readFileAsDataUrl } from "./lib/image-utils";
-import { CanvasNodeType, type CanvasConnection, type CanvasGenerationConfig, type CanvasNodeData, type CanvasNodeMetadata, type ContextMenuState, type ConnectionHandle, type Position, type SelectionBox, type ViewportTransform } from "./types";
+import { CanvasNodeType, type CanvasConnection, type CanvasGenerationConfig, type CanvasInteractionMode, type CanvasNodeData, type CanvasNodeMetadata, type ContextMenuState, type ConnectionHandle, type Position, type SelectionBox, type ViewportTransform } from "./types";
 import type { ReferenceImage } from "./types-media";
 import { PromptOptimizeDialog } from "@/components/PromptOptimizeDialog";
 import { AiTextGenerateDialog } from "./components/canvas-ai-text-dialog";
@@ -249,6 +249,7 @@ export function CanvasEditor({ projectId, onBack, onRequireApiKey, showToast, sh
   const [viewport, setViewport] = useState<ViewportTransform>(() => project?.viewport ?? { x: 0, y: 0, k: 1 });
   const [backgroundMode, setBackgroundMode] = useState(project?.backgroundMode ?? "lines");
   const [showImageInfo, setShowImageInfo] = useState(project?.showImageInfo ?? false);
+  const [interactionMode, setInteractionMode] = useState<CanvasInteractionMode>("select");
 
   const [selectedIds, setSelectedIds] = useState<string[]>([]);
   const [selectedConnectionId, setSelectedConnectionId] = useState<string | null>(null);
@@ -1213,7 +1214,7 @@ export function CanvasEditor({ projectId, onBack, onRequireApiKey, showToast, sh
 
   const handleCanvasSelectionStart = useCallback(
     (event: React.PointerEvent) => {
-      const additive = event.shiftKey;
+      const additive = event.shiftKey || event.ctrlKey || event.metaKey;
       const world = worldFromClient(event.clientX, event.clientY);
       interaction.current = { kind: "selection", additive, initial: additive ? selectedIds : [] };
       setSelectionBox({ startWorldX: world.x, startWorldY: world.y, currentWorldX: world.x, currentWorldY: world.y, additive, initialSelectedNodeIds: additive ? selectedIds : [] });
@@ -1281,7 +1282,13 @@ export function CanvasEditor({ projectId, onBack, onRequireApiKey, showToast, sh
             const maxY = Math.max(box.startWorldY, box.currentWorldY);
             const inside = nodes.filter((node) => node.position.x + node.width >= minX && node.position.x <= maxX && node.position.y + node.height >= minY && node.position.y <= maxY).map((node) => node.id);
             setSelectedConnectionId(null);
-            setSelectedIds([...new Set([...box.initialSelectedNodeIds, ...inside])]);
+            if (box.additive) {
+              const next = new Set(box.initialSelectedNodeIds);
+              inside.forEach((id) => next.has(id) ? next.delete(id) : next.add(id));
+              setSelectedIds([...next]);
+            } else {
+              setSelectedIds(inside);
+            }
           }
           return null;
         });
@@ -1844,6 +1851,7 @@ export function CanvasEditor({ projectId, onBack, onRequireApiKey, showToast, sh
       <InfiniteCanvas
         containerRef={containerRef}
         viewport={viewport}
+        interactionMode={interactionMode}
         backgroundMode={backgroundMode}
         onViewportChange={setViewport}
         onCanvasMouseDown={handleCanvasSelectionStart}
@@ -2075,6 +2083,7 @@ export function CanvasEditor({ projectId, onBack, onRequireApiKey, showToast, sh
         canRedo={redoStack.length > 0}
         backgroundMode={backgroundMode}
         showImageInfo={showImageInfo}
+        interactionMode={interactionMode}
         showPromptGallery={showPromptGallery}
         onAddImage={() => addNode(CanvasNodeType.Image)}
         onAddText={() => addNode(CanvasNodeType.Text)}
@@ -2090,6 +2099,7 @@ export function CanvasEditor({ projectId, onBack, onRequireApiKey, showToast, sh
         onSearch={() => setNodeSearchOpen(true)}
         onBackgroundModeChange={setBackgroundMode}
         onShowImageInfoChange={setShowImageInfo}
+        onInteractionModeChange={setInteractionMode}
       />
 
       <CanvasZoomControls

--- a/frontend/src/components/canvas/CanvasEditor.tsx
+++ b/frontend/src/components/canvas/CanvasEditor.tsx
@@ -1777,6 +1777,7 @@ export function CanvasEditor({ projectId, onBack, onRequireApiKey, showToast, sh
               }}
               onConnectStart={handleConnectStart}
               onResizeStart={handleResizeStart}
+              onTitleChange={(nodeId, title) => patchNode(nodeId, (current) => ({ ...current, title }))}
               onContentChange={handleTextChange}
               onUploadToNode={handleNodeUpload}
               onImportToNode={handleNodeImport}

--- a/frontend/src/components/canvas/CanvasEditor.tsx
+++ b/frontend/src/components/canvas/CanvasEditor.tsx
@@ -1336,6 +1336,7 @@ export function CanvasEditor({ projectId, onBack, onRequireApiKey, showToast, sh
       }
       if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "v") {
         if (!clipboard.current.nodes.length) return;
+        event.preventDefault();
         pushHistory();
         const duplicated = duplicateCanvasSelection(clipboard.current.nodes, clipboard.current.connections, clipboard.current.nodes.map((node) => node.id), nanoid, 40);
         setNodes((prev) => [...prev, ...duplicated.nodes]);

--- a/frontend/src/components/canvas/CanvasEditor.tsx
+++ b/frontend/src/components/canvas/CanvasEditor.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { ArrowLeft } from "lucide-react";
+import { ArrowLeft, Check, CloudAlert, LoaderCircle } from "lucide-react";
 import { nanoid } from "nanoid";
 
 import { Button } from "@/components/ui/button";
@@ -19,12 +19,14 @@ import { CanvasPromptGalleryImportDialog } from "./components/canvas-prompt-gall
 import { CanvasTemplateDialog, type CanvasTemplate } from "./components/canvas-template-dialog";
 import { CanvasContextMenu } from "./components/canvas-context-menu";
 import { CanvasConfigNodePanel } from "./components/canvas-config-node-panel";
+import { CanvasBatchGenerationDialog, CanvasGenerationPreviewDialog, type CanvasBatchPreviewItem } from "./components/canvas-generation-preview-dialog";
+import { CanvasNodeSearchDialog } from "./components/canvas-node-search-dialog";
 import { FullscreenImageViewer } from "./components/fullscreen-image-viewer";
 import type { ImageActionPayload } from "@/lib/image-actions";
 import { CanvasCropDialog, CanvasUpscaleDialog, CanvasSplitDialog, CanvasAngleDialog } from "./components/canvas-node-dialogs";
 import { canvasTheme } from "./lib/canvas-theme";
 import { getNodeSpec } from "./constants";
-import { useCanvasStore } from "./stores/use-canvas-store";
+import { flushPendingCanvasSave, useCanvasStore } from "./stores/use-canvas-store";
 import { useCanvasConfigStore } from "./stores/use-canvas-config-store";
 import { CanvasApiKeyMissingError, submitNodeGeneration, pollNodeTask, checkExistingTask, type CanvasGeneratedImage } from "./canvas-generation-service";
 import { buildNodeGenerationContext, buildNodeGenerationInputs, hydrateNodeGenerationContext } from "./components/canvas-node-generation";
@@ -50,6 +52,8 @@ import { readSseStream } from "@/lib/sse-stream-parser";
 import { MODEL_IMAGE_LIMITS } from "@/lib/gemini-config";
 import { normalizeModel } from "@/lib/model-capabilities";
 import type { PromptWithKey } from "@/lib/prompt-gallery-data";
+import { duplicateCanvasSelection } from "./utils/canvas-clipboard";
+import { arrangeCanvasNodes, layoutCanvasGraph, type CanvasArrangeMode } from "./utils/canvas-layout";
 
 type DialogState = { type: "crop" | "split" | "upscale" | "angle"; nodeId: string; source: string } | null;
 
@@ -64,6 +68,22 @@ type CanvasEditorProps = {
 };
 
 const MAX_HISTORY = 50;
+
+function connectedNodeIds(seedId: string, connections: CanvasConnection[]) {
+  const visited = new Set([seedId]);
+  const queue = [seedId];
+  while (queue.length) {
+    const id = queue.shift()!;
+    for (const connection of connections) {
+      const next = connection.fromNodeId === id ? connection.toNodeId : connection.toNodeId === id ? connection.fromNodeId : null;
+      if (next && !visited.has(next)) {
+        visited.add(next);
+        queue.push(next);
+      }
+    }
+  }
+  return [...visited];
+}
 
 /**
  * 构建AI文本生成的系统提示词
@@ -216,6 +236,7 @@ export function CanvasEditor({ projectId, onBack, onRequireApiKey, showToast, sh
   const theme = canvasTheme;
   const openProject = useCanvasStore((state) => state.openProject);
   const updateProject = useCanvasStore((state) => state.updateProject);
+  const saveStatus = useCanvasStore((state) => state.saveStatus);
   const renameProject = useCanvasStore((state) => state.renameProject);
   const projectTitle = useCanvasStore((state) => state.projects.find((item) => item.id === projectId)?.title) ?? "画布";
   const defaultConfig = useCanvasConfigStore((state) => state.config);
@@ -254,6 +275,9 @@ export function CanvasEditor({ projectId, onBack, onRequireApiKey, showToast, sh
   const [replaceConfirm, setReplaceConfirm] = useState<{ nodeId: string; stored: UploadedImage } | null>(null);
   const [textReplaceConfirm, setTextReplaceConfirm] = useState<{ nodeId: string; content: string } | null>(null);
   const [fullscreenImageUrl, setFullscreenImageUrl] = useState<{ src: string; title: string; actionPayload?: ImageActionPayload } | null>(null);
+  const [generationPreviewNodeId, setGenerationPreviewNodeId] = useState<string | null>(null);
+  const [batchGenerationOpen, setBatchGenerationOpen] = useState(false);
+  const [nodeSearchOpen, setNodeSearchOpen] = useState(false);
   const [nodeZIndexMap, setNodeZIndexMap] = useState<Record<string, number>>({});
   const topZIndexRef = useRef(1);
 
@@ -268,12 +292,13 @@ export function CanvasEditor({ projectId, onBack, onRequireApiKey, showToast, sh
     | null
   >(null);
   const gestureActive = useRef(false);
-  const clipboard = useRef<CanvasNodeData[]>([]);
+  const clipboard = useRef<{ nodes: CanvasNodeData[]; connections: CanvasConnection[] }>({ nodes: [], connections: [] });
   const activeGenerationsRef = useRef<Map<string, AbortController>>(new Map());
   const retryCooldownRef = useRef<Map<string, number>>(new Map());
   const textGenerationControllersRef = useRef<Map<string, AbortController>>(new Map());
   const [undoStack, setUndoStack] = useState<HistorySnapshot[]>([]);
   const [redoStack, setRedoStack] = useState<HistorySnapshot[]>([]);
+  const continuousHistoryTimersRef = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
 
   // 提示词优化（结合连接的上游图片/文字引用）
   const [optimizeOpen, setOptimizeOpen] = useState(false);
@@ -284,11 +309,24 @@ export function CanvasEditor({ projectId, onBack, onRequireApiKey, showToast, sh
   const [optimizeOriginalPrompt, setOptimizeOriginalPrompt] = useState("");
   const optimizeHandleRef = useRef<StreamPromptOptimizeHandle | null>(null);
 
-  // ---- persistence: sync local state to store (store debounces IndexedDB writes) ----
+  // ---- persistence: content changes affect updatedAt; view-only changes do not ----
   useEffect(() => {
     if (!project) return;
-    updateProject(projectId, { nodes, connections, viewport, backgroundMode, showImageInfo });
-  }, [nodes, connections, viewport, backgroundMode, showImageInfo, project, projectId, updateProject]);
+    updateProject(projectId, { nodes, connections });
+  }, [nodes, connections, project, projectId, updateProject]);
+
+  useEffect(() => {
+    if (!project) return;
+    updateProject(projectId, { viewport, backgroundMode, showImageInfo }, { touchUpdatedAt: false });
+  }, [viewport, backgroundMode, showImageInfo, project, projectId, updateProject]);
+
+  useEffect(() => {
+    const flushWhenHidden = () => {
+      if (document.visibilityState === "hidden") void flushPendingCanvasSave();
+    };
+    document.addEventListener("visibilitychange", flushWhenHidden);
+    return () => document.removeEventListener("visibilitychange", flushWhenHidden);
+  }, []);
 
   // ---- resolve image blob URLs for nodes that only have a storageKey ----
   useEffect(() => {
@@ -349,6 +387,17 @@ export function CanvasEditor({ projectId, onBack, onRequireApiKey, showToast, sh
     });
     setRedoStack([]);
   }, [snapshot]);
+  const clearContinuousHistory = useCallback(() => {
+    continuousHistoryTimersRef.current.forEach((timer) => clearTimeout(timer));
+    continuousHistoryTimersRef.current.clear();
+  }, []);
+  const recordContinuousHistory = useCallback((key: string) => {
+    const currentTimer = continuousHistoryTimersRef.current.get(key);
+    if (!currentTimer) pushHistory();
+    else clearTimeout(currentTimer);
+    continuousHistoryTimersRef.current.set(key, setTimeout(() => continuousHistoryTimersRef.current.delete(key), 600));
+  }, [pushHistory]);
+  useEffect(() => clearContinuousHistory, [clearContinuousHistory]);
   const beginGesture = useCallback(() => {
     if (gestureActive.current) return;
     gestureActive.current = true;
@@ -356,20 +405,22 @@ export function CanvasEditor({ projectId, onBack, onRequireApiKey, showToast, sh
   }, [pushHistory]);
   const undo = useCallback(() => {
     if (!undoStack.length) return;
+    clearContinuousHistory();
     const previous = undoStack[undoStack.length - 1];
     setRedoStack((redo) => [...redo, snapshot()]);
     setUndoStack((stack) => stack.slice(0, -1));
     setNodes(previous.nodes);
     setConnections(previous.connections);
-  }, [snapshot, undoStack]);
+  }, [clearContinuousHistory, snapshot, undoStack]);
   const redo = useCallback(() => {
     if (!redoStack.length) return;
+    clearContinuousHistory();
     const next = redoStack[redoStack.length - 1];
     setUndoStack((stack) => [...stack, snapshot()]);
     setRedoStack((redo) => redo.slice(0, -1));
     setNodes(next.nodes);
     setConnections(next.connections);
-  }, [snapshot, redoStack]);
+  }, [clearContinuousHistory, snapshot, redoStack]);
 
   const worldFromClient = useCallback(
     (clientX: number, clientY: number): Position => {
@@ -408,10 +459,10 @@ export function CanvasEditor({ projectId, onBack, onRequireApiKey, showToast, sh
   }, []);
 
   const addNode = useCallback(
-    (type: CanvasNodeType) => {
+    (type: CanvasNodeType, position?: Position) => {
       pushHistory();
       const spec = getNodeSpec(type);
-      const center = viewportCenterWorld();
+      const center = position ?? viewportCenterWorld();
       const metadata: CanvasNodeMetadata = { ...spec.metadata };
       if (type === CanvasNodeType.Config) metadata.genConfig = defaultConfig;
       const node: CanvasNodeData = {
@@ -443,6 +494,19 @@ export function CanvasEditor({ projectId, onBack, onRequireApiKey, showToast, sh
     [pushHistory],
   );
 
+  const pasteClipboardAt = useCallback((position: Position) => {
+    if (!clipboard.current.nodes.length) return;
+    const duplicated = duplicateCanvasSelection(clipboard.current.nodes, clipboard.current.connections, clipboard.current.nodes.map((node) => node.id), nanoid, 0);
+    const minX = Math.min(...duplicated.nodes.map((node) => node.position.x));
+    const minY = Math.min(...duplicated.nodes.map((node) => node.position.y));
+    const placedNodes = duplicated.nodes.map((node) => ({ ...node, position: { x: node.position.x - minX + position.x, y: node.position.y - minY + position.y } }));
+    pushHistory();
+    setNodes((current) => [...current, ...placedNodes]);
+    setConnections((current) => [...current, ...duplicated.connections]);
+    setSelectedIds(placedNodes.map((node) => node.id));
+    setSelectedConnectionId(null);
+  }, [pushHistory]);
+
   const deleteConnection = useCallback(
     (connectionId: string | null) => {
       if (!connectionId) return;
@@ -455,16 +519,15 @@ export function CanvasEditor({ projectId, onBack, onRequireApiKey, showToast, sh
 
   const duplicateNodes = useCallback(
     (ids: string[]) => {
-      const idSet = new Set(ids);
-      const sources = nodes.filter((node) => idSet.has(node.id));
-      if (!sources.length) return;
+      const duplicated = duplicateCanvasSelection(nodes, connections, ids, nanoid, 32);
+      if (!duplicated.nodes.length) return;
       pushHistory();
-      const clones = sources.map((node) => ({ ...node, id: nanoid(), position: { x: node.position.x + 32, y: node.position.y + 32 }, metadata: { ...node.metadata } }));
-      setNodes((prev) => [...prev, ...clones]);
+      setNodes((prev) => [...prev, ...duplicated.nodes]);
+      setConnections((prev) => [...prev, ...duplicated.connections]);
       setSelectedConnectionId(null);
-      setSelectedIds(clones.map((node) => node.id));
+      setSelectedIds(duplicated.nodes.map((node) => node.id));
     },
-    [nodes, pushHistory],
+    [connections, nodes, pushHistory],
   );
 
   // ---- image source: upload / asset library / save to assets ----
@@ -784,6 +847,34 @@ export function CanvasEditor({ projectId, onBack, onRequireApiKey, showToast, sh
     [connections, defaultConfig, nodes],
   );
 
+  const selectedConfigNodes = useMemo(
+    () => nodes.filter((node) => selectedIds.includes(node.id) && node.type === CanvasNodeType.Config),
+    [nodes, selectedIds],
+  );
+  const previewNode = useMemo(
+    () => nodes.find((node) => node.id === generationPreviewNodeId && node.type === CanvasNodeType.Config) ?? null,
+    [generationPreviewNodeId, nodes],
+  );
+  const previewContext = useMemo(() => previewNode
+    ? buildNodeGenerationContext(previewNode.id, nodes, connections, previewNode.metadata?.composerContent ?? previewNode.metadata?.prompt ?? "")
+    : null, [connections, nodes, previewNode]);
+  const batchPreviewItems = useMemo<CanvasBatchPreviewItem[]>(() => selectedConfigNodes.map((node) => {
+    const prompt = node.metadata?.composerContent ?? node.metadata?.prompt ?? "";
+    const context = buildNodeGenerationContext(node.id, nodes, connections, prompt);
+    const limit = getConfigReferenceLimit(node);
+    const config = node.metadata?.genConfig ?? defaultConfig;
+    const reason = !context.routeValid
+      ? "路线已失效"
+      : !context.prompt.trim()
+        ? "提示词为空"
+        : limit.exceeded
+          ? "参考图超限"
+          : busyNodeIds.includes(node.id)
+            ? "正在生成"
+            : undefined;
+    return { node, valid: !reason, reason, imageCount: Number(config.count) || 1 };
+  }), [busyNodeIds, connections, defaultConfig, getConfigReferenceLimit, nodes, selectedConfigNodes]);
+
   // 对单个结果图片节点启动独立生成任务（提交 + 轮询）。
   const startNodeGeneration = useCallback(
     async (nodeId: string, promptText: string, referenceImages: ReferenceImage[], genConfig: CanvasGenerationConfig, sourceNodeId: string) => {
@@ -874,7 +965,11 @@ export function CanvasEditor({ projectId, onBack, onRequireApiKey, showToast, sh
         if (targetIds.length < count) {
           const needed = count - targetIds.length;
           for (let i = 0; i < needed; i++) {
-            const node = createImageNode({ x: sourceNode.position.x + sourceNode.width + 80 + (targetIds.length + i) * 400, y: sourceNode.position.y + sourceNode.height + 60 });
+            const resultIndex = targetIds.length + 1;
+            const node = createImageNode(
+              { x: sourceNode.position.x + sourceNode.width + 80 + (resultIndex - 1) * 400, y: sourceNode.position.y + sourceNode.height + 60 },
+              { title: `${sourceNode.title} - 结果 ${resultIndex}` },
+            );
             targetIds.push(node.id);
             newConnections.push({ id: nanoid(), fromNodeId: sourceNode.id, toNodeId: node.id });
             setNodes((prev) => [...prev, node]);
@@ -886,7 +981,10 @@ export function CanvasEditor({ projectId, onBack, onRequireApiKey, showToast, sh
       } else {
         // 非锁定模式：新建 count 个结果节点
         for (let i = 0; i < count; i++) {
-          const node = createImageNode({ x: sourceNode.position.x + sourceNode.width + 80 + i * 400, y: sourceNode.position.y });
+          const node = createImageNode(
+            { x: sourceNode.position.x + sourceNode.width + 80 + i * 400, y: sourceNode.position.y },
+            { title: `${sourceNode.title} - 结果 ${i + 1}` },
+          );
           targetIds.push(node.id);
           newConnections.push({ id: nanoid(), fromNodeId: sourceNode.id, toNodeId: node.id });
           setNodes((prev) => [...prev, node]);
@@ -1167,8 +1265,9 @@ export function CanvasEditor({ projectId, onBack, onRequireApiKey, showToast, sh
           if (conn?.targetId) {
             const from = current.handle.handleType === "source" ? current.handle.nodeId : conn.targetId;
             const to = current.handle.handleType === "source" ? conn.targetId : current.handle.nodeId;
-            if (from !== to) {
-              setConnections((prev) => (prev.some((item) => item.fromNodeId === from && item.toNodeId === to) ? prev : [...prev, { id: nanoid(), fromNodeId: from, toNodeId: to }]));
+            if (from !== to && !connections.some((item) => item.fromNodeId === from && item.toNodeId === to)) {
+              pushHistory();
+              setConnections((prev) => [...prev, { id: nanoid(), fromNodeId: from, toNodeId: to }]);
             }
           }
           return null;
@@ -1197,7 +1296,7 @@ export function CanvasEditor({ projectId, onBack, onRequireApiKey, showToast, sh
       window.removeEventListener("pointermove", handleMove);
       window.removeEventListener("pointerup", handleUp);
     };
-  }, [nodes, viewport.k, worldFromClient]);
+  }, [connections, nodes, pushHistory, viewport.k, worldFromClient]);
 
   // ---- keyboard ----
   useEffect(() => {
@@ -1215,17 +1314,27 @@ export function CanvasEditor({ projectId, onBack, onRequireApiKey, showToast, sh
         return;
       }
       if (editing) return;
+      if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "f") {
+        event.preventDefault();
+        setNodeSearchOpen(true);
+        return;
+      }
       if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "c") {
-        clipboard.current = nodes.filter((node) => selectedIds.includes(node.id)).map((node) => ({ ...node, metadata: { ...node.metadata } }));
+        const selectedSet = new Set(selectedIds);
+        clipboard.current = {
+          nodes: nodes.filter((node) => selectedSet.has(node.id)).map((node) => ({ ...node, metadata: { ...node.metadata } })),
+          connections: connections.filter((connection) => selectedSet.has(connection.fromNodeId) && selectedSet.has(connection.toNodeId)).map((connection) => ({ ...connection })),
+        };
         return;
       }
       if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "v") {
-        if (!clipboard.current.length) return;
+        if (!clipboard.current.nodes.length) return;
         pushHistory();
-        const clones = clipboard.current.map((node) => ({ ...node, id: nanoid(), position: { x: node.position.x + 40, y: node.position.y + 40 }, metadata: { ...node.metadata } }));
-        setNodes((prev) => [...prev, ...clones]);
+        const duplicated = duplicateCanvasSelection(clipboard.current.nodes, clipboard.current.connections, clipboard.current.nodes.map((node) => node.id), nanoid, 40);
+        setNodes((prev) => [...prev, ...duplicated.nodes]);
+        setConnections((prev) => [...prev, ...duplicated.connections]);
         setSelectedConnectionId(null);
-        setSelectedIds(clones.map((node) => node.id));
+        setSelectedIds(duplicated.nodes.map((node) => node.id));
         return;
       }
       if (event.key === "Delete" || event.key === "Backspace") {
@@ -1240,7 +1349,7 @@ export function CanvasEditor({ projectId, onBack, onRequireApiKey, showToast, sh
     };
     window.addEventListener("keydown", handler);
     return () => window.removeEventListener("keydown", handler);
-  }, [deleteConnection, deleteNodes, nodes, pushHistory, redo, selectedConnectionId, selectedIds, undo]);
+  }, [connections, deleteConnection, deleteNodes, nodes, pushHistory, redo, selectedConnectionId, selectedIds, undo]);
 
   // ---- 粘贴图片/文本：选中单个同类节点则填充，否则在视口中心新建 ----
   useEffect(() => {
@@ -1336,20 +1445,57 @@ export function CanvasEditor({ projectId, onBack, onRequireApiKey, showToast, sh
   const nodeById = useCallback((id: string) => nodes.find((node) => node.id === id), [nodes]);
   const contextNode = contextMenu?.type === "node" ? nodeById(contextMenu.nodeId) : undefined;
 
+  const focusNode = useCallback((node: CanvasNodeData) => {
+    const scale = Math.min(Math.max(viewport.k, 0.5), 1.25);
+    setViewport({
+      x: viewportSize.width / 2 - (node.position.x + node.width / 2) * scale,
+      y: viewportSize.height / 2 - (node.position.y + node.height / 2) * scale,
+      k: scale,
+    });
+    setSelectedConnectionId(null);
+    setSelectedIds([node.id]);
+  }, [viewport.k, viewportSize.height, viewportSize.width]);
+
   const handleTextChange = useCallback(
     (nodeId: string, content: string) => {
+      recordContinuousHistory(`text:${nodeId}`);
       patchNode(nodeId, (node) => ({ ...node, metadata: { ...node.metadata, content } }));
     },
-    [patchNode],
+    [patchNode, recordContinuousHistory],
   );
+
+  const runSelectedGenerations = useCallback(() => {
+    const validNodes = batchPreviewItems.filter((item) => item.valid).map((item) => item.node);
+    setBatchGenerationOpen(false);
+    validNodes.forEach((node) => void runGeneration(node));
+  }, [batchPreviewItems, runGeneration]);
 
   const handleConfigChange = useCallback(
     (nodeId: string, patch: Partial<CanvasGenerationConfig>) => {
+      recordContinuousHistory(`config:${nodeId}`);
       patchNode(nodeId, (node) => ({ ...node, metadata: { ...node.metadata, genConfig: { ...(node.metadata?.genConfig ?? defaultConfig), ...patch } } }));
       setStoreConfig(patch);
     },
-    [defaultConfig, patchNode, setStoreConfig],
+    [defaultConfig, patchNode, recordContinuousHistory, setStoreConfig],
   );
+
+  const handleArrange = useCallback((mode: CanvasArrangeMode | "graph") => {
+    const targetIds = mode === "graph"
+      ? selectedIds.length > 1
+        ? selectedIds
+        : selectedIds.length === 1
+          ? connectedNodeIds(selectedIds[0], connections)
+          : nodes.map((node) => node.id)
+      : selectedIds;
+    if (targetIds.length < 2) {
+      showToast("至少需要两个节点才能排列", "info");
+      return;
+    }
+    pushHistory();
+    setNodes((current) => mode === "graph"
+      ? layoutCanvasGraph(current, connections, targetIds)
+      : arrangeCanvasNodes(current, targetIds, mode));
+  }, [connections, nodes, pushHistory, selectedIds, showToast]);
 
   // ---- AI 文本生成对话框逻辑 ----
   const handleAiTextOpen = useCallback((nodeId: string) => {
@@ -1440,6 +1586,7 @@ export function CanvasEditor({ projectId, onBack, onRequireApiKey, showToast, sh
     const nodeId = aiTextTargetNodeId;
     if (!nodeId || !aiTextGenerated) return;
 
+    pushHistory();
     patchNode(nodeId, (n) => ({
       ...n,
       metadata: {
@@ -1447,7 +1594,7 @@ export function CanvasEditor({ projectId, onBack, onRequireApiKey, showToast, sh
         content: aiTextGenerated,
       },
     }));
-  }, [aiTextTargetNodeId, aiTextGenerated, patchNode]);
+  }, [aiTextTargetNodeId, aiTextGenerated, patchNode, pushHistory]);
 
   const handleAiTextCancel = useCallback(() => {
     setAiTextDialogOpen(false);
@@ -1642,12 +1789,13 @@ export function CanvasEditor({ projectId, onBack, onRequireApiKey, showToast, sh
 
   const handleOptimizeAccept = useCallback(() => {
     if (optimizedText && optimizeNodeId) {
+      pushHistory();
       patchNode(optimizeNodeId, (node) => ({ ...node, metadata: { ...node.metadata, composerContent: optimizedText } }));
     }
     optimizeHandleRef.current = null;
     setOptimizedText("");
     setOptimizeError(null);
-  }, [optimizedText, optimizeNodeId, patchNode]);
+  }, [optimizedText, optimizeNodeId, patchNode, pushHistory]);
 
   const selectionRect = useMemo(() => {
     if (!selectionBox) return null;
@@ -1700,7 +1848,14 @@ export function CanvasEditor({ projectId, onBack, onRequireApiKey, showToast, sh
         onViewportChange={setViewport}
         onCanvasMouseDown={handleCanvasSelectionStart}
         onCanvasDeselect={() => { setSelectedIds([]); setSelectedConnectionId(null); setContextMenu(null); if (titleDraft !== null) { renameProject(projectId, titleDraft); setTitleDraft(null); } }}
-        onContextMenu={(event) => event.preventDefault()}
+        onContextMenu={(event) => {
+          event.preventDefault();
+          const target = event.target instanceof Element ? event.target : null;
+          if (target?.closest("[data-node-id],[data-connection-id]")) return;
+          setSelectedIds([]);
+          setSelectedConnectionId(null);
+          setContextMenu({ type: "canvas", x: event.clientX, y: event.clientY, position: worldFromClient(event.clientX, event.clientY) });
+        }}
         onDrop={(event) => {
           event.preventDefault();
           if (event.dataTransfer?.files?.length) void ingestFiles(event.dataTransfer.files, worldFromClient(event.clientX, event.clientY));
@@ -1777,7 +1932,10 @@ export function CanvasEditor({ projectId, onBack, onRequireApiKey, showToast, sh
               }}
               onConnectStart={handleConnectStart}
               onResizeStart={handleResizeStart}
-              onTitleChange={(nodeId, title) => patchNode(nodeId, (current) => ({ ...current, title }))}
+              onTitleChange={(nodeId, title) => {
+                pushHistory();
+                patchNode(nodeId, (current) => ({ ...current, title }));
+              }}
               onContentChange={handleTextChange}
               onUploadToNode={handleNodeUpload}
               onImportToNode={handleNodeImport}
@@ -1802,6 +1960,7 @@ export function CanvasEditor({ projectId, onBack, onRequireApiKey, showToast, sh
                 }
               }}
               onToggleRenderMode={(nodeId) => {
+                pushHistory();
                 patchNode(nodeId, (n) => ({
                   ...n,
                   metadata: { ...n.metadata, renderMode: n.metadata?.renderMode === "markdown" ? "plain" : "markdown" },
@@ -1821,10 +1980,17 @@ export function CanvasEditor({ projectId, onBack, onRequireApiKey, showToast, sh
                   routesTruncated={routeEnumeration.truncated}
                   busy={busyNodeIds.includes(configNode.id)}
                   optimizing={optimizing && optimizeNodeId === configNode.id}
-                  onPromptChange={(value) => patchNode(configNode.id, (n) => ({ ...n, metadata: { ...n.metadata, composerContent: value } }))}
+                  onPromptChange={(value) => {
+                    recordContinuousHistory(`prompt:${configNode.id}`);
+                    patchNode(configNode.id, (n) => ({ ...n, metadata: { ...n.metadata, composerContent: value } }));
+                  }}
                   onConfigChange={(patch) => handleConfigChange(configNode.id, patch)}
-                  onToggleLock={() => patchNode(configNode.id, (n) => ({ ...n, metadata: { ...n.metadata, lockResultNodes: !n.metadata?.lockResultNodes } }))}
+                  onToggleLock={() => {
+                    pushHistory();
+                    patchNode(configNode.id, (n) => ({ ...n, metadata: { ...n.metadata, lockResultNodes: !n.metadata?.lockResultNodes } }));
+                  }}
                   onRouteChange={(value) => {
+                    pushHistory();
                     if (value === MANUAL_PROMPT_ROUTE_VALUE) {
                       patchNode(configNode.id, (n) => ({ ...n, metadata: { ...n.metadata, promptRouteSelection: { mode: "manual" } } }));
                       return;
@@ -1838,6 +2004,7 @@ export function CanvasEditor({ projectId, onBack, onRequireApiKey, showToast, sh
                   }}
                   onSelect={onSelect}
                   onOptimizePrompt={() => void handleOptimizePrompt(configNode)}
+                  onPreview={() => setGenerationPreviewNodeId(configNode.id)}
                   onGenerate={() => void runGeneration(configNode)}
                 />
               )}
@@ -1855,7 +2022,13 @@ export function CanvasEditor({ projectId, onBack, onRequireApiKey, showToast, sh
 
       {/* 顶部返回 + 标题（点击重命名） */}
       <div data-canvas-no-zoom className="absolute top-4 left-4 z-50 flex items-center gap-2" onPointerDown={(event) => event.stopPropagation()}>
-        <Button variant="outline" size="sm" onClick={onBack}>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => {
+            void flushPendingCanvasSave().then(onBack);
+          }}
+        >
           <ArrowLeft className="size-4" />
           画布列表
         </Button>
@@ -1888,10 +2061,16 @@ export function CanvasEditor({ projectId, onBack, onRequireApiKey, showToast, sh
             {projectTitle}
           </button>
         )}
+        <span className="flex items-center gap-1 text-[11px] text-muted-foreground" aria-live="polite">
+          {saveStatus === "saving" ? <LoaderCircle className="size-3 animate-spin" /> : saveStatus === "error" ? <CloudAlert className="size-3 text-destructive" /> : <Check className="size-3" />}
+          {saveStatus === "saving" ? "保存中" : saveStatus === "error" ? "保存失败" : "已保存"}
+        </span>
       </div>
 
       <CanvasToolbar
         selectedCount={selectedIds.length + (selectedConnectionId ? 1 : 0)}
+        nodeCount={nodes.length}
+        selectedConfigCount={selectedConfigNodes.length}
         canUndo={undoStack.length > 0}
         canRedo={redoStack.length > 0}
         backgroundMode={backgroundMode}
@@ -1906,6 +2085,9 @@ export function CanvasEditor({ projectId, onBack, onRequireApiKey, showToast, sh
         onUndo={undo}
         onRedo={redo}
         onDelete={() => selectedConnectionId ? deleteConnection(selectedConnectionId) : deleteNodes(selectedIds)}
+        onArrange={handleArrange}
+        onGenerateSelected={() => setBatchGenerationOpen(true)}
+        onSearch={() => setNodeSearchOpen(true)}
         onBackgroundModeChange={setBackgroundMode}
         onShowImageInfoChange={setShowImageInfo}
       />
@@ -1961,8 +2143,16 @@ export function CanvasEditor({ projectId, onBack, onRequireApiKey, showToast, sh
               deleteConnection(contextMenu.connectionId);
             }
           },
+          onAddNodeAt: (type) => {
+            if (contextMenu?.type === "canvas") addNode(type, contextMenu.position);
+          },
+          onPasteAt: () => {
+            if (contextMenu?.type === "canvas") pasteClipboardAt(contextMenu.position);
+          },
+          canPaste: clipboard.current.nodes.length > 0,
           onToggleRenderMode: contextNode?.type === CanvasNodeType.Text
             ? () => {
+                pushHistory();
                 patchNode(contextNode.id, (n) => ({
                   ...n,
                   metadata: { ...n.metadata, renderMode: n.metadata?.renderMode === "markdown" ? "plain" : "markdown" },
@@ -1971,6 +2161,7 @@ export function CanvasEditor({ projectId, onBack, onRequireApiKey, showToast, sh
             : undefined,
           onAnnotationChangeColor: contextNode?.type === CanvasNodeType.TextAnnotation
             ? () => {
+                pushHistory();
                 const colors = ["#fef3c7", "#dbeafe", "#fce7f3", "#d1fae5", "#fce4ec", "#ede9fe"];
                 const current = contextNode.metadata?.backgroundColor || "";
                 const next = colors[(colors.indexOf(current) + 1) % colors.length];
@@ -1982,6 +2173,7 @@ export function CanvasEditor({ projectId, onBack, onRequireApiKey, showToast, sh
             : undefined,
           onAnnotationChangeFontSize: contextNode?.type === CanvasNodeType.TextAnnotation
             ? () => {
+                pushHistory();
                 const sizes = [14, 16, 18, 20, 22, 24];
                 const current = contextNode.metadata?.fontSize || 14;
                 const next = sizes[(sizes.indexOf(current) + 1) % sizes.length];
@@ -2000,6 +2192,22 @@ export function CanvasEditor({ projectId, onBack, onRequireApiKey, showToast, sh
       <CanvasPromptGalleryImportDialog open={promptGalleryOpen} importing={promptGalleryImporting} onOpenChange={setPromptGalleryOpen} onConfirm={(prompt) => void importPromptGalleryTemplate(prompt)} />
 
       <CanvasTemplateDialog open={templateOpen} onOpenChange={setTemplateOpen} onConfirm={(template) => applyCanvasTemplate(template)} />
+
+      <CanvasGenerationPreviewDialog
+        open={Boolean(previewNode)}
+        onOpenChange={(open) => !open && setGenerationPreviewNodeId(null)}
+        node={previewNode}
+        context={previewContext}
+        config={previewNode?.metadata?.genConfig ?? defaultConfig}
+        onCopy={(text) => {
+          void navigator.clipboard?.writeText(text);
+          showToast("最终提示词已复制", "success");
+        }}
+      />
+
+      <CanvasBatchGenerationDialog open={batchGenerationOpen} onOpenChange={setBatchGenerationOpen} items={batchPreviewItems} onConfirm={runSelectedGenerations} />
+
+      <CanvasNodeSearchDialog open={nodeSearchOpen} onOpenChange={setNodeSearchOpen} nodes={nodes} onSelect={focusNode} />
 
       <PromptOptimizeDialog
         open={optimizeOpen}

--- a/frontend/src/components/canvas/CanvasEditor.tsx
+++ b/frontend/src/components/canvas/CanvasEditor.tsx
@@ -224,6 +224,7 @@ export function CanvasEditor({ projectId, onBack, onRequireApiKey, showToast, sh
   const [showImageInfo, setShowImageInfo] = useState(project?.showImageInfo ?? false);
 
   const [selectedIds, setSelectedIds] = useState<string[]>([]);
+  const [selectedConnectionId, setSelectedConnectionId] = useState<string | null>(null);
   const [contextMenu, setContextMenu] = useState<ContextMenuState | null>(null);
   const [connecting, setConnecting] = useState<{ handle: ConnectionHandle; mouseWorld: Position; targetId?: string } | null>(null);
   const [selectionBox, setSelectionBox] = useState<SelectionBox | null>(null);
@@ -417,6 +418,7 @@ export function CanvasEditor({ projectId, onBack, onRequireApiKey, showToast, sh
         metadata,
       };
       setNodes((prev) => [...prev, node]);
+      setSelectedConnectionId(null);
       setSelectedIds([node.id]);
     },
     [defaultConfig, pushHistory, viewportCenterWorld],
@@ -429,7 +431,18 @@ export function CanvasEditor({ projectId, onBack, onRequireApiKey, showToast, sh
       const idSet = new Set(ids);
       setNodes((prev) => prev.filter((node) => !idSet.has(node.id)));
       setConnections((prev) => prev.filter((connection) => !idSet.has(connection.fromNodeId) && !idSet.has(connection.toNodeId)));
+      setSelectedConnectionId(null);
       setSelectedIds((prev) => prev.filter((id) => !idSet.has(id)));
+    },
+    [pushHistory],
+  );
+
+  const deleteConnection = useCallback(
+    (connectionId: string | null) => {
+      if (!connectionId) return;
+      pushHistory();
+      setConnections((prev) => prev.filter((connection) => connection.id !== connectionId));
+      setSelectedConnectionId((selectedId) => (selectedId === connectionId ? null : selectedId));
     },
     [pushHistory],
   );
@@ -442,6 +455,7 @@ export function CanvasEditor({ projectId, onBack, onRequireApiKey, showToast, sh
       pushHistory();
       const clones = sources.map((node) => ({ ...node, id: nanoid(), position: { x: node.position.x + 32, y: node.position.y + 32 }, metadata: { ...node.metadata } }));
       setNodes((prev) => [...prev, ...clones]);
+      setSelectedConnectionId(null);
       setSelectedIds(clones.map((node) => node.id));
     },
     [nodes, pushHistory],
@@ -663,6 +677,7 @@ export function CanvasEditor({ projectId, onBack, onRequireApiKey, showToast, sh
         pushHistory();
         setNodes((prev) => [...prev, ...upstreamNodes, configNode]);
         setConnections((prev) => [...prev, ...newConnections]);
+        setSelectedConnectionId(null);
         setSelectedIds([configNode.id]);
         setPromptGalleryOpen(false);
         showToast(
@@ -715,6 +730,7 @@ export function CanvasEditor({ projectId, onBack, onRequireApiKey, showToast, sh
       pushHistory();
       setNodes((prev) => [...prev, textNode, configNode]);
       setConnections((prev) => [...prev, connection]);
+      setSelectedConnectionId(null);
       setSelectedIds([configNode.id]);
       setTemplateOpen(false);
       showToast(`已导入模板：${template.title}`, "success");
@@ -1033,6 +1049,7 @@ export function CanvasEditor({ projectId, onBack, onRequireApiKey, showToast, sh
     (event: React.PointerEvent, nodeId: string) => {
       if (event.button !== 0) return;
       event.stopPropagation();
+      setSelectedConnectionId(null);
       setContextMenu(null); // 点击节点时关闭右键菜单
 
       // 点击节点时自动置顶（Fix 2: z-index stacking）
@@ -1154,6 +1171,7 @@ export function CanvasEditor({ projectId, onBack, onRequireApiKey, showToast, sh
             const minY = Math.min(box.startWorldY, box.currentWorldY);
             const maxY = Math.max(box.startWorldY, box.currentWorldY);
             const inside = nodes.filter((node) => node.position.x + node.width >= minX && node.position.x <= maxX && node.position.y + node.height >= minY && node.position.y <= maxY).map((node) => node.id);
+            setSelectedConnectionId(null);
             setSelectedIds([...new Set([...box.initialSelectedNodeIds, ...inside])]);
           }
           return null;
@@ -1196,11 +1214,15 @@ export function CanvasEditor({ projectId, onBack, onRequireApiKey, showToast, sh
         pushHistory();
         const clones = clipboard.current.map((node) => ({ ...node, id: nanoid(), position: { x: node.position.x + 40, y: node.position.y + 40 }, metadata: { ...node.metadata } }));
         setNodes((prev) => [...prev, ...clones]);
+        setSelectedConnectionId(null);
         setSelectedIds(clones.map((node) => node.id));
         return;
       }
       if (event.key === "Delete" || event.key === "Backspace") {
-        if (selectedIds.length) {
+        if (selectedConnectionId) {
+          event.preventDefault();
+          deleteConnection(selectedConnectionId);
+        } else if (selectedIds.length) {
           event.preventDefault();
           deleteNodes(selectedIds);
         }
@@ -1208,7 +1230,7 @@ export function CanvasEditor({ projectId, onBack, onRequireApiKey, showToast, sh
     };
     window.addEventListener("keydown", handler);
     return () => window.removeEventListener("keydown", handler);
-  }, [deleteNodes, nodes, pushHistory, redo, selectedIds, undo]);
+  }, [deleteConnection, deleteNodes, nodes, pushHistory, redo, selectedConnectionId, selectedIds, undo]);
 
   // ---- 粘贴图片/文本：选中单个同类节点则填充，否则在视口中心新建 ----
   useEffect(() => {
@@ -1241,6 +1263,7 @@ export function CanvasEditor({ projectId, onBack, onRequireApiKey, showToast, sh
           const size = fitNodeSize(stored.width, stored.height, 320, 320);
           const node = createImageNode(viewportCenterWorld(), { metadata: storedToMetadata(stored), width: size.width, height: size.height });
           setNodes((prev) => [...prev, node]);
+          setSelectedConnectionId(null);
           setSelectedIds([node.id]);
         } catch {
           showToast("粘贴图片失败", "error");
@@ -1274,6 +1297,7 @@ export function CanvasEditor({ projectId, onBack, onRequireApiKey, showToast, sh
       pushHistory();
       const node = createTextNode(viewportCenterWorld(), text);
       setNodes((prev) => [...prev, node]);
+      setSelectedConnectionId(null);
       setSelectedIds([node.id]);
     };
     window.addEventListener("paste", handlePasteText);
@@ -1655,7 +1679,7 @@ export function CanvasEditor({ projectId, onBack, onRequireApiKey, showToast, sh
         backgroundMode={backgroundMode}
         onViewportChange={setViewport}
         onCanvasMouseDown={handleCanvasSelectionStart}
-        onCanvasDeselect={() => { setSelectedIds([]); setContextMenu(null); if (titleDraft !== null) { renameProject(projectId, titleDraft); setTitleDraft(null); } }}
+        onCanvasDeselect={() => { setSelectedIds([]); setSelectedConnectionId(null); setContextMenu(null); if (titleDraft !== null) { renameProject(projectId, titleDraft); setTitleDraft(null); } }}
         onContextMenu={(event) => event.preventDefault()}
         onDrop={(event) => {
           event.preventDefault();
@@ -1667,10 +1691,25 @@ export function CanvasEditor({ projectId, onBack, onRequireApiKey, showToast, sh
             const from = nodeById(connection.fromNodeId);
             const to = nodeById(connection.toNodeId);
             if (!from || !to) return null;
-            const active = selectedIds.includes(connection.fromNodeId) || selectedIds.includes(connection.toNodeId);
+            const active = selectedConnectionId === connection.id || selectedIds.includes(connection.fromNodeId) || selectedIds.includes(connection.toNodeId);
             return (
               <g key={connection.id} className="pointer-events-auto">
-                <ConnectionPath connection={connection} from={from} to={to} active={active} onSelect={() => undefined} onContextMenu={(event) => setContextMenu({ type: "connection", x: event.clientX, y: event.clientY, connectionId: connection.id })} />
+                <ConnectionPath
+                  connection={connection}
+                  from={from}
+                  to={to}
+                  active={active}
+                  onSelect={() => {
+                    setSelectedIds([]);
+                    setSelectedConnectionId(connection.id);
+                    setContextMenu(null);
+                  }}
+                  onContextMenu={(event) => {
+                    setSelectedIds([]);
+                    setSelectedConnectionId(connection.id);
+                    setContextMenu({ type: "connection", x: event.clientX, y: event.clientY, connectionId: connection.id });
+                  }}
+                />
               </g>
             );
           })}
@@ -1691,9 +1730,10 @@ export function CanvasEditor({ projectId, onBack, onRequireApiKey, showToast, sh
               zIndex={nodeZIndexMap[node.id] ?? 1}
               showImageInfo={showImageInfo}
               onPointerDownNode={handleNodePointerDown}
-              onSelectNode={(id) => { if (!selectedIds.includes(id)) setSelectedIds([id]); }}
+              onSelectNode={(id) => { setSelectedConnectionId(null); if (!selectedIds.includes(id)) setSelectedIds([id]); }}
               onContextMenu={(event, id) => {
                 event.preventDefault();
+                setSelectedConnectionId(null);
                 if (!selectedIds.includes(id)) setSelectedIds([id]);
                 setContextMenu({ type: "node", x: event.clientX, y: event.clientY, nodeId: id });
               }}
@@ -1796,7 +1836,7 @@ export function CanvasEditor({ projectId, onBack, onRequireApiKey, showToast, sh
       </div>
 
       <CanvasToolbar
-        selectedCount={selectedIds.length}
+        selectedCount={selectedIds.length + (selectedConnectionId ? 1 : 0)}
         canUndo={undoStack.length > 0}
         canRedo={redoStack.length > 0}
         backgroundMode={backgroundMode}
@@ -1810,7 +1850,7 @@ export function CanvasEditor({ projectId, onBack, onRequireApiKey, showToast, sh
         onOpenTemplate={() => setTemplateOpen(true)}
         onUndo={undo}
         onRedo={redo}
-        onDelete={() => deleteNodes(selectedIds)}
+        onDelete={() => selectedConnectionId ? deleteConnection(selectedConnectionId) : deleteNodes(selectedIds)}
         onBackgroundModeChange={setBackgroundMode}
         onShowImageInfoChange={setShowImageInfo}
       />
@@ -1863,8 +1903,7 @@ export function CanvasEditor({ projectId, onBack, onRequireApiKey, showToast, sh
           onAngle: () => contextNode && openDialog("angle", contextNode),
           onDeleteConnection: () => {
             if (contextMenu?.type === "connection") {
-              pushHistory();
-              setConnections((prev) => prev.filter((connection) => connection.id !== contextMenu.connectionId));
+              deleteConnection(contextMenu.connectionId);
             }
           },
           onToggleRenderMode: contextNode?.type === CanvasNodeType.Text

--- a/frontend/src/components/canvas/CanvasEditor.tsx
+++ b/frontend/src/components/canvas/CanvasEditor.tsx
@@ -32,6 +32,12 @@ import { buildNodeMentionReferences } from "./utils/canvas-resource-references";
 import { fitNodeSize } from "./utils/canvas-node-size";
 import { getImageBlob, imageToDataUrl, resolveImageUrl, uploadImage, type UploadedImage } from "./lib/image-storage";
 import { imageReferenceLabel } from "./lib/image-reference-prompt";
+import {
+  enumeratePromptRoutes,
+  findSelectedPromptRoute,
+  isInvalidPromptRouteSelection,
+  MANUAL_PROMPT_ROUTE_VALUE,
+} from "./lib/canvas-prompt-routes";
 import { compressReferenceDataUrl, readFileAsDataUrl } from "./lib/image-utils";
 import { CanvasNodeType, type CanvasConnection, type CanvasGenerationConfig, type CanvasNodeData, type CanvasNodeMetadata, type ContextMenuState, type ConnectionHandle, type Position, type SelectionBox, type ViewportTransform } from "./types";
 import type { ReferenceImage } from "./types-media";
@@ -833,11 +839,12 @@ export function CanvasEditor({ projectId, onBack, onRequireApiKey, showToast, sh
   const runGeneration = useCallback(
     async (sourceNode: CanvasNodeData) => {
       const promptText = (sourceNode.metadata?.composerContent ?? sourceNode.metadata?.prompt ?? "").trim();
-      if (!promptText) { showToast("请输入提示词", "info"); return; }
       const genConfig: CanvasGenerationConfig = sourceNode.metadata?.genConfig ?? defaultConfig;
       const locked = Boolean(sourceNode.metadata?.lockResultNodes);
       const count = genConfig.count;
       const context = buildNodeGenerationContext(sourceNode.id, nodes, connections, promptText);
+      if (!context.routeValid) { showToast("所选提示词路线已失效，请重新选择", "error"); return; }
+      if (!context.prompt.trim()) { showToast("请输入提示词", "info"); return; }
       const model = normalizeModel(genConfig.model);
       const maxReferenceImages = typeof MODEL_IMAGE_LIMITS[model]?.max === "number" ? MODEL_IMAGE_LIMITS[model].max : 1;
 
@@ -914,10 +921,13 @@ export function CanvasEditor({ projectId, onBack, onRequireApiKey, showToast, sh
       const sourceNode = configConnection ? nodes.find((n) => n.id === configConnection.fromNodeId) : undefined;
       const promptText = sourceNode?.metadata?.composerContent ?? sourceNode?.metadata?.prompt ?? node.metadata?.prompt ?? "";
       const genConfig = sourceNode?.metadata?.genConfig ?? defaultConfig;
-      if (!promptText) { showToast("无法获取提示词", "info"); return; }
 
       void (async () => {
-        const context = sourceNode ? buildNodeGenerationContext(sourceNode.id, nodes, connections, promptText) : { prompt: promptText, referenceImages: [], textCount: 0, imageCount: 0 };
+        const context = sourceNode
+          ? buildNodeGenerationContext(sourceNode.id, nodes, connections, promptText)
+          : { prompt: promptText, referenceImages: [], textCount: 0, imageCount: 0, routeValid: true };
+        if (!context.routeValid) { showToast("所选提示词路线已失效，请重新选择", "error"); return; }
+        if (!context.prompt.trim()) { showToast("无法获取提示词", "info"); return; }
         const hydrated = await hydrateNodeGenerationContext(context);
         void startNodeGeneration(node.id, hydrated.prompt || promptText, hydrated.referenceImages, genConfig, sourceNode?.id ?? "");
       })();
@@ -1313,6 +1323,16 @@ export function CanvasEditor({ projectId, onBack, onRequireApiKey, showToast, sh
     return set;
   }, [connections, selectedIds]);
 
+  const activePromptRoute = useMemo(() => {
+    if (selectedIds.length !== 1) return null;
+    const selectedNode = nodes.find((node) => node.id === selectedIds[0]);
+    if (selectedNode?.type !== CanvasNodeType.Config) return null;
+    const routes = enumeratePromptRoutes(selectedNode.id, nodes, connections).routes;
+    return findSelectedPromptRoute(selectedNode.metadata?.promptRouteSelection, routes);
+  }, [connections, nodes, selectedIds]);
+  const activeRouteNodeIds = useMemo(() => new Set(activePromptRoute?.nodeIds ?? []), [activePromptRoute]);
+  const activeRouteConnectionIds = useMemo(() => new Set(activePromptRoute?.connectionIds ?? []), [activePromptRoute]);
+
   const nodeById = useCallback((id: string) => nodes.find((node) => node.id === id), [nodes]);
   const contextNode = contextMenu?.type === "node" ? nodeById(contextMenu.nodeId) : undefined;
 
@@ -1691,7 +1711,9 @@ export function CanvasEditor({ projectId, onBack, onRequireApiKey, showToast, sh
             const from = nodeById(connection.fromNodeId);
             const to = nodeById(connection.toNodeId);
             if (!from || !to) return null;
-            const active = selectedConnectionId === connection.id || selectedIds.includes(connection.fromNodeId) || selectedIds.includes(connection.toNodeId);
+            const endpointSelected = selectedIds.includes(connection.fromNodeId) || selectedIds.includes(connection.toNodeId);
+            const active = selectedConnectionId === connection.id || (!activePromptRoute && endpointSelected);
+            const routeActive = activeRouteConnectionIds.has(connection.id);
             return (
               <g key={connection.id} className="pointer-events-auto">
                 <ConnectionPath
@@ -1699,6 +1721,7 @@ export function CanvasEditor({ projectId, onBack, onRequireApiKey, showToast, sh
                   from={from}
                   to={to}
                   active={active}
+                  routeActive={routeActive}
                   onSelect={() => {
                     setSelectedIds([]);
                     setSelectedConnectionId(connection.id);
@@ -1718,6 +1741,20 @@ export function CanvasEditor({ projectId, onBack, onRequireApiKey, showToast, sh
 
         {nodes.map((node) => {
           const referenceLimit = node.type === CanvasNodeType.Config ? getConfigReferenceLimit(node) : null;
+          const routeEnumeration = node.type === CanvasNodeType.Config
+            ? enumeratePromptRoutes(node.id, nodes, connections)
+            : { routes: [], truncated: false };
+          const routeSelection = node.metadata?.promptRouteSelection ?? { mode: "manual" as const };
+          const selectedRoute = findSelectedPromptRoute(routeSelection, routeEnumeration.routes);
+          const routeInvalid = isInvalidPromptRouteSelection(routeSelection, routeEnumeration.routes);
+          const routeValue = routeInvalid
+            ? "invalid"
+            : selectedRoute?.id ?? MANUAL_PROMPT_ROUTE_VALUE;
+          const routeOptions = [
+            { value: MANUAL_PROMPT_ROUTE_VALUE, label: "手动编排（@ 引用）" },
+            ...(routeInvalid ? [{ value: "invalid", label: "所选路线已失效，请重新选择", disabled: true }] : []),
+            ...routeEnumeration.routes.map((route) => ({ value: route.id, label: route.label })),
+          ];
           return (
             <CanvasNode
               key={node.id}
@@ -1725,6 +1762,7 @@ export function CanvasEditor({ projectId, onBack, onRequireApiKey, showToast, sh
               imageUrl={nodeImageUrl(node)}
               isSelected={selectedIds.includes(node.id)}
               isRelated={relatedIds.has(node.id)}
+              isRouteActive={activeRouteNodeIds.has(node.id)}
               isConnectionTarget={connecting?.targetId === node.id}
               referenceLimitExceeded={Boolean(referenceLimit?.exceeded)}
               zIndex={nodeZIndexMap[node.id] ?? 1}
@@ -1776,11 +1814,27 @@ export function CanvasEditor({ projectId, onBack, onRequireApiKey, showToast, sh
                   config={configNode.metadata?.genConfig ?? defaultConfig}
                   lockResultNodes={Boolean(configNode.metadata?.lockResultNodes)}
                   referenceLimit={referenceLimit ?? getConfigReferenceLimit(configNode)}
+                  routeValue={routeValue}
+                  routeOptions={routeOptions}
+                  routeInvalid={routeInvalid}
+                  routesTruncated={routeEnumeration.truncated}
                   busy={busyNodeIds.includes(configNode.id)}
                   optimizing={optimizing && optimizeNodeId === configNode.id}
                   onPromptChange={(value) => patchNode(configNode.id, (n) => ({ ...n, metadata: { ...n.metadata, composerContent: value } }))}
                   onConfigChange={(patch) => handleConfigChange(configNode.id, patch)}
                   onToggleLock={() => patchNode(configNode.id, (n) => ({ ...n, metadata: { ...n.metadata, lockResultNodes: !n.metadata?.lockResultNodes } }))}
+                  onRouteChange={(value) => {
+                    if (value === MANUAL_PROMPT_ROUTE_VALUE) {
+                      patchNode(configNode.id, (n) => ({ ...n, metadata: { ...n.metadata, promptRouteSelection: { mode: "manual" } } }));
+                      return;
+                    }
+                    const route = routeEnumeration.routes.find((item) => item.id === value);
+                    if (!route) return;
+                    patchNode(configNode.id, (n) => ({
+                      ...n,
+                      metadata: { ...n.metadata, promptRouteSelection: { mode: "route", connectionIds: route.connectionIds } },
+                    }));
+                  }}
                   onSelect={onSelect}
                   onOptimizePrompt={() => void handleOptimizePrompt(configNode)}
                   onGenerate={() => void runGeneration(configNode)}

--- a/frontend/src/components/canvas/__tests__/CanvasEditor.connections.test.tsx
+++ b/frontend/src/components/canvas/__tests__/CanvasEditor.connections.test.tsx
@@ -90,4 +90,62 @@ describe("CanvasEditor connections", () => {
       expect(useCanvasStore.getState().openProject(project.id)?.connections).toHaveLength(0);
     });
   });
+
+  it("copies the connections internal to a multi-node selection", async () => {
+    const { container } = renderEditor();
+    const nodeA = container.querySelector<HTMLElement>('[data-node-id="node-a"]')!;
+    const nodeB = container.querySelector<HTMLElement>('[data-node-id="node-b"]')!;
+
+    fireEvent.pointerDown(nodeA, { button: 0, clientX: 20, clientY: 20 });
+    fireEvent.pointerUp(window);
+    fireEvent.pointerDown(nodeB, { button: 0, ctrlKey: true, clientX: 440, clientY: 20 });
+    fireEvent.pointerUp(window);
+    fireEvent.keyDown(window, { key: "c", ctrlKey: true });
+    fireEvent.keyDown(window, { key: "v", ctrlKey: true });
+
+    await waitFor(() => {
+      const saved = useCanvasStore.getState().openProject(project.id)!;
+      expect(saved.nodes).toHaveLength(4);
+      expect(saved.connections).toHaveLength(2);
+      const clonedIds = saved.nodes.filter((node) => node.id !== "node-a" && node.id !== "node-b").map((node) => node.id);
+      expect(saved.connections.some((connection) => clonedIds.includes(connection.fromNodeId) && clonedIds.includes(connection.toNodeId))).toBe(true);
+    });
+  });
+
+  it("aligns selected nodes from the arrange menu", async () => {
+    const { container } = renderEditor();
+    const nodeA = container.querySelector<HTMLElement>('[data-node-id="node-a"]')!;
+    const nodeB = container.querySelector<HTMLElement>('[data-node-id="node-b"]')!;
+    fireEvent.pointerDown(nodeA, { button: 0, clientX: 20, clientY: 20 });
+    fireEvent.pointerUp(window);
+    fireEvent.pointerDown(nodeB, { button: 0, ctrlKey: true, clientX: 440, clientY: 20 });
+    fireEvent.pointerUp(window);
+
+    fireEvent.click(screen.getByRole("button", { name: "排列节点" }));
+    fireEvent.click(await screen.findByRole("menuitem", { name: "左对齐" }));
+
+    await waitFor(() => {
+      const saved = useCanvasStore.getState().openProject(project.id)!;
+      expect(saved.nodes.find((node) => node.id === "node-a")?.position.x).toBe(0);
+      expect(saved.nodes.find((node) => node.id === "node-b")?.position.x).toBe(0);
+    });
+  });
+
+  it("creates a node at the right-clicked canvas position", async () => {
+    const { container } = renderEditor();
+    const canvas = container.querySelector<HTMLElement>(".cursor-grab")!;
+
+    fireEvent.contextMenu(canvas, { clientX: 300, clientY: 260 });
+    fireEvent.click(await screen.findByRole("button", { name: "在此添加文本节点" }));
+
+    await waitFor(() => {
+      const saved = useCanvasStore.getState().openProject(project.id)!;
+      expect(saved.nodes).toHaveLength(3);
+      const createdNode = saved.nodes[2];
+      expect({
+        x: createdNode.position.x + createdNode.width / 2,
+        y: createdNode.position.y + createdNode.height / 2,
+      }).toEqual({ x: 300, y: 260 });
+    });
+  });
 });

--- a/frontend/src/components/canvas/__tests__/CanvasEditor.connections.test.tsx
+++ b/frontend/src/components/canvas/__tests__/CanvasEditor.connections.test.tsx
@@ -1,0 +1,93 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { CanvasEditor } from "../CanvasEditor";
+import { useCanvasStore, type CanvasProject } from "../stores/use-canvas-store";
+import { CanvasNodeType } from "../types";
+
+const project: CanvasProject = {
+  id: "project-1",
+  title: "Connection deletion",
+  createdAt: "2026-07-27T00:00:00.000Z",
+  updatedAt: "2026-07-27T00:00:00.000Z",
+  nodes: [
+    {
+      id: "node-a",
+      type: CanvasNodeType.Text,
+      title: "A",
+      position: { x: 0, y: 0 },
+      width: 240,
+      height: 160,
+      metadata: { content: "A" },
+    },
+    {
+      id: "node-b",
+      type: CanvasNodeType.Text,
+      title: "B",
+      position: { x: 420, y: 0 },
+      width: 240,
+      height: 160,
+      metadata: { content: "B" },
+    },
+  ],
+  connections: [{ id: "connection-1", fromNodeId: "node-a", toNodeId: "node-b" }],
+  backgroundMode: "lines",
+  showImageInfo: false,
+  viewport: { x: 0, y: 0, k: 1 },
+};
+
+class ResizeObserverStub {
+  observe() {}
+  disconnect() {}
+  unobserve() {}
+}
+
+describe("CanvasEditor connections", () => {
+  beforeEach(() => {
+    vi.stubGlobal("ResizeObserver", ResizeObserverStub);
+    useCanvasStore.setState({ hydrated: true, projects: [project] });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+  });
+
+  function renderEditor() {
+    return render(
+      <CanvasEditor
+        projectId={project.id}
+        onBack={() => undefined}
+        onRequireApiKey={() => undefined}
+        showToast={() => undefined}
+      />,
+    );
+  }
+
+  it("deletes the selected connection with the Delete key", async () => {
+    const { container } = renderEditor();
+
+    const connection = container.querySelector<SVGPathElement>('[data-connection-id="connection-1"]');
+    expect(connection).not.toBeNull();
+
+    fireEvent.click(connection!);
+    fireEvent.keyDown(window, { key: "Delete" });
+
+    await waitFor(() => {
+      expect(useCanvasStore.getState().openProject(project.id)?.connections).toHaveLength(0);
+    });
+  });
+
+  it("deletes the selected connection from the toolbar", async () => {
+    const { container } = renderEditor();
+    const connection = container.querySelector<SVGPathElement>('[data-connection-id="connection-1"]');
+    expect(connection).not.toBeNull();
+
+    fireEvent.click(connection!);
+    fireEvent.click(screen.getByRole("button", { name: "删除选中" }));
+
+    await waitFor(() => {
+      expect(useCanvasStore.getState().openProject(project.id)?.connections).toHaveLength(0);
+    });
+  });
+});

--- a/frontend/src/components/canvas/__tests__/CanvasEditor.connections.test.tsx
+++ b/frontend/src/components/canvas/__tests__/CanvasEditor.connections.test.tsx
@@ -113,6 +113,40 @@ describe("CanvasEditor connections", () => {
     });
   });
 
+  it("prevents the system clipboard from also pasting when duplicating copied nodes", async () => {
+    const { container } = renderEditor();
+    const nodeA = container.querySelector<HTMLElement>('[data-node-id="node-a"]')!;
+    fireEvent.pointerDown(nodeA, { button: 0, clientX: 20, clientY: 20 });
+    fireEvent.pointerUp(window);
+    fireEvent.keyDown(window, { key: "c", ctrlKey: true });
+
+    const pasteShortcut = new KeyboardEvent("keydown", {
+      key: "v",
+      ctrlKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
+
+    expect(fireEvent(window, pasteShortcut)).toBe(false);
+    await waitFor(() => {
+      const saved = useCanvasStore.getState().openProject(project.id)!;
+      expect(saved.nodes).toHaveLength(3);
+      expect(saved.nodes.map((node) => node.metadata?.content)).toEqual(["A", "B", "A"]);
+    });
+  });
+
+  it("allows system clipboard paste when no canvas nodes were copied", () => {
+    renderEditor();
+    const pasteShortcut = new KeyboardEvent("keydown", {
+      key: "v",
+      ctrlKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
+
+    expect(fireEvent(window, pasteShortcut)).toBe(true);
+  });
+
   it("aligns selected nodes from the arrange menu", async () => {
     const { container } = renderEditor();
     const nodeA = container.querySelector<HTMLElement>('[data-node-id="node-a"]')!;

--- a/frontend/src/components/canvas/__tests__/CanvasEditor.connections.test.tsx
+++ b/frontend/src/components/canvas/__tests__/CanvasEditor.connections.test.tsx
@@ -45,6 +45,7 @@ class ResizeObserverStub {
 describe("CanvasEditor connections", () => {
   beforeEach(() => {
     vi.stubGlobal("ResizeObserver", ResizeObserverStub);
+    HTMLElement.prototype.setPointerCapture = vi.fn();
     useCanvasStore.setState({ hydrated: true, projects: [project] });
   });
 
@@ -133,7 +134,7 @@ describe("CanvasEditor connections", () => {
 
   it("creates a node at the right-clicked canvas position", async () => {
     const { container } = renderEditor();
-    const canvas = container.querySelector<HTMLElement>(".cursor-grab")!;
+    const canvas = container.querySelector<HTMLElement>("[data-canvas-mode]")!;
 
     fireEvent.contextMenu(canvas, { clientX: 300, clientY: 260 });
     fireEvent.click(await screen.findByRole("button", { name: "在此添加文本节点" }));
@@ -146,6 +147,68 @@ describe("CanvasEditor connections", () => {
         x: createdNode.position.x + createdNode.width / 2,
         y: createdNode.position.y + createdNode.height / 2,
       }).toEqual({ x: 300, y: 260 });
+    });
+  });
+
+  it("box-selects nodes by default when dragging the blank canvas", async () => {
+    const { container } = renderEditor();
+    const canvas = container.querySelector<HTMLElement>("[data-canvas-mode]")!;
+
+    expect(screen.getByRole("button", { name: "选择模式" })).toHaveAttribute("data-pressed");
+    fireEvent.pointerDown(canvas, { button: 0, pointerId: 1, clientX: 0, clientY: 0 });
+    fireEvent.pointerMove(window, { pointerId: 1, clientX: 700, clientY: 200 });
+    fireEvent.pointerUp(window, { pointerId: 1 });
+
+    await waitFor(() => {
+      expect(container.querySelector('[data-node-id="node-a"]')).toHaveAttribute("data-selected", "true");
+      expect(container.querySelector('[data-node-id="node-b"]')).toHaveAttribute("data-selected", "true");
+    });
+  });
+
+  it("toggles nodes inside a modifier-assisted box selection", async () => {
+    const { container } = renderEditor();
+    const nodeA = container.querySelector<HTMLElement>('[data-node-id="node-a"]')!;
+    const canvas = container.querySelector<HTMLElement>("[data-canvas-mode]")!;
+    fireEvent.pointerDown(nodeA, { button: 0, clientX: 20, clientY: 20 });
+    fireEvent.pointerUp(window);
+
+    fireEvent.pointerDown(canvas, { button: 0, pointerId: 4, shiftKey: true, clientX: 0, clientY: 0 });
+    fireEvent.pointerMove(window, { pointerId: 4, clientX: 700, clientY: 200 });
+    fireEvent.pointerUp(window, { pointerId: 4 });
+
+    await waitFor(() => {
+      expect(container.querySelector('[data-node-id="node-a"]')).not.toHaveAttribute("data-selected");
+      expect(container.querySelector('[data-node-id="node-b"]')).toHaveAttribute("data-selected", "true");
+    });
+  });
+
+  it("pans the blank canvas after switching to hand mode", async () => {
+    const { container } = renderEditor();
+    fireEvent.click(screen.getByRole("button", { name: "抓手模式" }));
+    const canvas = container.querySelector<HTMLElement>('[data-canvas-mode="pan"]')!;
+
+    fireEvent.pointerDown(canvas, { button: 0, pointerId: 2, clientX: 700, clientY: 400 });
+    fireEvent.pointerMove(window, { pointerId: 2, clientX: 750, clientY: 450 });
+    fireEvent.pointerUp(window, { pointerId: 2 });
+
+    await waitFor(() => {
+      expect(container.querySelector<HTMLElement>(".origin-top-left")).toHaveStyle("transform: translate(50px, 50px) scale(1)");
+    });
+  });
+
+  it("temporarily pans with Space while selection mode stays active", async () => {
+    const { container } = renderEditor();
+    const canvas = container.querySelector<HTMLElement>("[data-canvas-mode]")!;
+
+    fireEvent.keyDown(window, { code: "Space" });
+    fireEvent.pointerDown(canvas, { button: 0, pointerId: 3, clientX: 700, clientY: 400 });
+    fireEvent.pointerMove(window, { pointerId: 3, clientX: 730, clientY: 420 });
+    fireEvent.pointerUp(window, { pointerId: 3 });
+    fireEvent.keyUp(window, { code: "Space" });
+
+    await waitFor(() => {
+      expect(container.querySelector<HTMLElement>(".origin-top-left")).toHaveStyle("transform: translate(30px, 20px) scale(1)");
+      expect(screen.getByRole("button", { name: "选择模式" })).toHaveAttribute("data-pressed");
     });
   });
 });

--- a/frontend/src/components/canvas/__tests__/CanvasEditor.routes.test.tsx
+++ b/frontend/src/components/canvas/__tests__/CanvasEditor.routes.test.tsx
@@ -106,6 +106,41 @@ describe("CanvasEditor prompt routes", () => {
     });
   });
 
+  it("undoes a prompt route selection", async () => {
+    render(
+      <CanvasEditor projectId={project.id} onBack={() => undefined} onRequireApiKey={() => undefined} showToast={() => undefined} />,
+    );
+    const select = screen.getByRole("combobox", { name: "提示词路线" });
+    fireEvent.click(select);
+    const option = await screen.findByRole("option", { name: "核心提示词 -> 城市创意 -> 北京专属" });
+    fireEvent.pointerDown(option);
+    fireEvent.pointerUp(option);
+    fireEvent.click(option);
+    await waitFor(() => {
+      expect(useCanvasStore.getState().openProject(project.id)?.nodes.find((node) => node.id === "config-1")?.metadata?.promptRouteSelection?.mode).toBe("route");
+    });
+    fireEvent.keyDown(window, { key: "z", ctrlKey: true });
+
+    await waitFor(() => {
+      expect(useCanvasStore.getState().openProject(project.id)?.nodes.find((node) => node.id === "config-1")?.metadata?.promptRouteSelection).toBeUndefined();
+    });
+  });
+
+  it("undoes a burst of text input as one edit", async () => {
+    const { container } = render(
+      <CanvasEditor projectId={project.id} onBack={() => undefined} onRequireApiKey={() => undefined} showToast={() => undefined} />,
+    );
+    const coreNode = container.querySelector('[data-node-id="core"]')!;
+    const textarea = within(coreNode as HTMLElement).getByRole("textbox");
+    fireEvent.change(textarea, { target: { value: "核心提示词 A" } });
+    fireEvent.change(textarea, { target: { value: "核心提示词 AB" } });
+    fireEvent.keyDown(window, { key: "z", ctrlKey: true });
+
+    await waitFor(() => {
+      expect(useCanvasStore.getState().openProject(project.id)?.nodes.find((node) => node.id === "core")?.metadata?.content).toBe("核心提示词");
+    });
+  });
+
   it("renames a node inline and refreshes route labels", async () => {
     const seeded = structuredClone(project);
     const core = seeded.nodes.find((node) => node.id === "core")!;
@@ -144,6 +179,22 @@ describe("CanvasEditor prompt routes", () => {
     fireEvent.change(emptyInput, { target: { value: "   " } });
     fireEvent.blur(emptyInput);
     expect(getTitleHeader()).toHaveTextContent("核心提示词");
+  });
+
+  it("undoes an inline node rename as one edit", async () => {
+    const { container } = render(
+      <CanvasEditor projectId={project.id} onBack={() => undefined} onRequireApiKey={() => undefined} showToast={() => undefined} />,
+    );
+    const coreNode = container.querySelector('[data-node-id="core"]')!;
+    fireEvent.doubleClick(within(coreNode as HTMLElement).getByTitle("双击重命名节点"));
+    const titleInput = within(coreNode as HTMLElement).getByRole("textbox", { name: "节点标题" });
+    fireEvent.change(titleInput, { target: { value: "新的核心标题" } });
+    fireEvent.keyDown(titleInput, { key: "Enter" });
+    fireEvent.keyDown(window, { key: "z", ctrlKey: true });
+
+    await waitFor(() => {
+      expect(useCanvasStore.getState().openProject(project.id)?.nodes.find((node) => node.id === "core")?.title).toBe("核心提示词");
+    });
   });
 
   it("highlights the selected config route", () => {
@@ -204,6 +255,96 @@ describe("CanvasEditor prompt routes", () => {
       expect(submitNodeGenerationMock).toHaveBeenCalledWith(expect.objectContaining({
         prompt: "核心提示词\n\n城市创意\n\n北京专属",
       }));
+      const resultNode = useCanvasStore.getState().openProject(project.id)?.nodes.find((node) => node.type === CanvasNodeType.Image);
+      expect(resultNode?.title).toBe("北京生成配置1 - 结果 1");
+    });
+  });
+
+  it("previews the final prompt before generation", async () => {
+    const seeded = structuredClone(project);
+    const config = seeded.nodes.find((node) => node.id === "config-1")!;
+    config.metadata = {
+      ...config.metadata,
+      promptRouteSelection: { mode: "route", connectionIds: ["core-concept", "concept-beijing", "beijing-config-1"] },
+    };
+    useCanvasStore.setState({ hydrated: true, projects: [seeded] });
+
+    render(<CanvasEditor projectId={project.id} onBack={() => undefined} onRequireApiKey={() => undefined} showToast={() => undefined} />);
+    fireEvent.click(screen.getByRole("button", { name: "预览最终提示词" }));
+
+    const dialog = await screen.findByRole("dialog", { name: "生成预览" });
+    expect(dialog.querySelector("pre")).toHaveTextContent("核心提示词");
+    expect(dialog.querySelector("pre")).toHaveTextContent("城市创意");
+    expect(dialog.querySelector("pre")).toHaveTextContent("北京专属");
+    expect(dialog.querySelector("pre")).toHaveTextContent("胶片海报质感");
+  });
+
+  it("preflights and submits multiple selected config nodes", async () => {
+    const seeded = structuredClone(project);
+    seeded.nodes.push({
+      id: "config-2",
+      title: "北京生成配置2",
+      type: CanvasNodeType.Config,
+      position: { x: 800, y: 380 },
+      width: 360,
+      height: 280,
+      metadata: { composerContent: "水墨海报质感" },
+    });
+    useCanvasStore.setState({ hydrated: true, projects: [seeded] });
+
+    const { container } = render(<CanvasEditor projectId={project.id} onBack={() => undefined} onRequireApiKey={() => undefined} showToast={() => undefined} />);
+    const config1 = container.querySelector<HTMLElement>('[data-node-id="config-1"]')!;
+    const config2 = container.querySelector<HTMLElement>('[data-node-id="config-2"]')!;
+    fireEvent.pointerDown(config1, { button: 0, clientX: 820, clientY: 80 });
+    fireEvent.pointerUp(window);
+    fireEvent.pointerDown(config2, { button: 0, ctrlKey: true, clientX: 820, clientY: 420 });
+    fireEvent.pointerUp(window);
+
+    fireEvent.click(screen.getByRole("button", { name: "生成所选配置" }));
+    const dialog = await screen.findByRole("dialog", { name: "批量生成" });
+    expect(within(dialog).getByText(/^已选择/)).toHaveTextContent("2 个配置");
+    fireEvent.click(within(dialog).getByRole("button", { name: /开始生成/ }));
+
+    await waitFor(() => expect(submitNodeGenerationMock).toHaveBeenCalledTimes(2));
+  });
+
+  it("searches for a node and focuses it on the canvas", async () => {
+    const { container } = render(<CanvasEditor projectId={project.id} onBack={() => undefined} onRequireApiKey={() => undefined} showToast={() => undefined} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "搜索节点" }));
+    fireEvent.change(await screen.findByRole("searchbox", { name: "搜索节点" }), { target: { value: "北京生成" } });
+    fireEvent.click(screen.getByRole("button", { name: "定位到 北京生成配置1" }));
+
+    await waitFor(() => {
+      const configNode = container.querySelector<HTMLElement>('[data-node-id="config-1"]')!;
+      expect(configNode).toHaveAttribute("data-selected", "true");
+    });
+  });
+
+  it("undoes a Markdown display-mode change", async () => {
+    const { container } = render(<CanvasEditor projectId={project.id} onBack={() => undefined} onRequireApiKey={() => undefined} showToast={() => undefined} />);
+    const coreNode = container.querySelector<HTMLElement>('[data-node-id="core"]')!;
+
+    fireEvent.contextMenu(coreNode, { clientX: 100, clientY: 100 });
+    fireEvent.click(await screen.findByRole("button", { name: "切换 Markdown / 纯文本" }));
+    await waitFor(() => {
+      expect(useCanvasStore.getState().openProject(project.id)?.nodes.find((node) => node.id === "core")?.metadata?.renderMode).toBe("markdown");
+    });
+
+    fireEvent.keyDown(window, { key: "z", ctrlKey: true });
+    await waitFor(() => {
+      expect(useCanvasStore.getState().openProject(project.id)?.nodes.find((node) => node.id === "core")?.metadata?.renderMode).toBeUndefined();
+    });
+  });
+
+  it("changes canvas display options from one settings menu", async () => {
+    render(<CanvasEditor projectId={project.id} onBack={() => undefined} onRequireApiKey={() => undefined} showToast={() => undefined} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "画布显示设置" }));
+    fireEvent.click(await screen.findByRole("menuitemradio", { name: "圆点背景" }));
+
+    await waitFor(() => {
+      expect(useCanvasStore.getState().openProject(project.id)?.backgroundMode).toBe("dots");
     });
   });
 

--- a/frontend/src/components/canvas/__tests__/CanvasEditor.routes.test.tsx
+++ b/frontend/src/components/canvas/__tests__/CanvasEditor.routes.test.tsx
@@ -1,0 +1,199 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { CanvasEditor } from "../CanvasEditor";
+import { useCanvasStore, type CanvasProject } from "../stores/use-canvas-store";
+import { CanvasNodeType, type CanvasNodeData } from "../types";
+
+const submitNodeGenerationMock = vi.hoisted(() => vi.fn());
+const pollNodeTaskMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../canvas-generation-service", async () => {
+  const actual = await vi.importActual<typeof import("../canvas-generation-service")>("../canvas-generation-service");
+  return {
+    ...actual,
+    submitNodeGeneration: submitNodeGenerationMock,
+    pollNodeTask: pollNodeTaskMock,
+  };
+});
+
+function textNode(id: string, title: string): CanvasNodeData {
+  return {
+    id,
+    title,
+    type: CanvasNodeType.Text,
+    position: { x: 40, y: 40 },
+    width: 240,
+    height: 160,
+    metadata: { content: title },
+  };
+}
+
+const project: CanvasProject = {
+  id: "route-project",
+  title: "Prompt routes",
+  createdAt: "2026-07-27T00:00:00.000Z",
+  updatedAt: "2026-07-27T00:00:00.000Z",
+  nodes: [
+    textNode("core", "核心提示词"),
+    textNode("concept", "城市创意"),
+    textNode("beijing", "北京专属"),
+    {
+      id: "config-1",
+      title: "北京生成配置1",
+      type: CanvasNodeType.Config,
+      position: { x: 800, y: 40 },
+      width: 360,
+      height: 280,
+      metadata: { composerContent: "胶片海报质感" },
+    },
+  ],
+  connections: [
+    { id: "core-concept", fromNodeId: "core", toNodeId: "concept" },
+    { id: "concept-beijing", fromNodeId: "concept", toNodeId: "beijing" },
+    { id: "core-beijing", fromNodeId: "core", toNodeId: "beijing" },
+    { id: "beijing-config-1", fromNodeId: "beijing", toNodeId: "config-1" },
+  ],
+  backgroundMode: "lines",
+  showImageInfo: false,
+  viewport: { x: 0, y: 0, k: 1 },
+};
+
+class ResizeObserverStub {
+  observe() {}
+  disconnect() {}
+  unobserve() {}
+}
+
+describe("CanvasEditor prompt routes", () => {
+  beforeEach(() => {
+    vi.stubGlobal("ResizeObserver", ResizeObserverStub);
+    useCanvasStore.setState({ hydrated: true, projects: [structuredClone(project)] });
+    submitNodeGenerationMock.mockReset();
+    submitNodeGenerationMock.mockResolvedValue("task-1");
+    pollNodeTaskMock.mockReset();
+    pollNodeTaskMock.mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+  });
+
+  it("lists complete routes and persists the selected route on the config", async () => {
+    render(
+      <CanvasEditor
+        projectId={project.id}
+        onBack={() => undefined}
+        onRequireApiKey={() => undefined}
+        showToast={() => undefined}
+      />,
+    );
+
+    const select = screen.getByRole("combobox", { name: "提示词路线" });
+    fireEvent.click(select);
+    const option = await screen.findByRole("option", { name: "核心提示词 -> 城市创意 -> 北京专属" });
+    fireEvent.pointerDown(option);
+    fireEvent.pointerUp(option);
+    fireEvent.click(option);
+
+    await waitFor(() => {
+      const config = useCanvasStore.getState().openProject(project.id)?.nodes.find((node) => node.id === "config-1");
+      expect(config?.metadata?.promptRouteSelection).toEqual({
+        mode: "route",
+        connectionIds: ["core-concept", "concept-beijing", "beijing-config-1"],
+      });
+    });
+  });
+
+  it("highlights the selected config route", () => {
+    const seeded = structuredClone(project);
+    const config = seeded.nodes.find((node) => node.id === "config-1")!;
+    config.metadata = {
+      ...config.metadata,
+      promptRouteSelection: { mode: "route", connectionIds: ["core-concept", "concept-beijing", "beijing-config-1"] },
+    };
+    seeded.nodes.push(textNode("alternate", "备用路线"));
+    seeded.connections.push({ id: "alternate-config", fromNodeId: "alternate", toNodeId: "config-1" });
+    useCanvasStore.setState({ hydrated: true, projects: [seeded] });
+
+    const { container } = render(
+      <CanvasEditor projectId={project.id} onBack={() => undefined} onRequireApiKey={() => undefined} showToast={() => undefined} />,
+    );
+    fireEvent.pointerDown(container.querySelector('[data-node-id="config-1"]')!, { button: 0, clientX: 900, clientY: 100 });
+
+    expect(container.querySelector('[data-node-id="core"]')).toHaveAttribute("data-route-active", "true");
+    expect(container.querySelector('[data-node-id="concept"]')).toHaveAttribute("data-route-active", "true");
+    expect(container.querySelector('[data-node-id="beijing"]')).toHaveAttribute("data-route-active", "true");
+    expect(container.querySelector('[data-connection-id="core-concept"]')).toHaveAttribute("data-route-active", "true");
+    expect(container.querySelector('[data-connection-id="core-beijing"]')).not.toHaveAttribute("data-route-active");
+    const alternateHitPath = container.querySelector('[data-connection-id="alternate-config"]');
+    expect(alternateHitPath?.nextElementSibling).toHaveAttribute("stroke", "var(--muted-foreground)");
+  });
+
+  it("marks a deleted selected route invalid and disables generation", () => {
+    const seeded = structuredClone(project);
+    seeded.connections = seeded.connections.filter((connection) => connection.id !== "core-concept");
+    const config = seeded.nodes.find((node) => node.id === "config-1")!;
+    config.metadata = {
+      ...config.metadata,
+      promptRouteSelection: { mode: "route", connectionIds: ["core-concept", "concept-beijing", "beijing-config-1"] },
+    };
+    useCanvasStore.setState({ hydrated: true, projects: [seeded] });
+
+    render(<CanvasEditor projectId={project.id} onBack={() => undefined} onRequireApiKey={() => undefined} showToast={() => undefined} />);
+
+    expect(screen.getByRole("combobox", { name: "提示词路线" })).toHaveTextContent("所选路线已失效，请重新选择");
+    expect(screen.getByRole("button", { name: "生成" })).toBeDisabled();
+  });
+
+  it("generates from a selected route when the config supplement is empty", async () => {
+    const seeded = structuredClone(project);
+    const config = seeded.nodes.find((node) => node.id === "config-1")!;
+    config.metadata = {
+      ...config.metadata,
+      composerContent: "",
+      promptRouteSelection: { mode: "route", connectionIds: ["core-concept", "concept-beijing", "beijing-config-1"] },
+    };
+    useCanvasStore.setState({ hydrated: true, projects: [seeded] });
+
+    render(<CanvasEditor projectId={project.id} onBack={() => undefined} onRequireApiKey={() => undefined} showToast={() => undefined} />);
+    fireEvent.click(screen.getByRole("button", { name: "生成" }));
+
+    await waitFor(() => {
+      expect(submitNodeGenerationMock).toHaveBeenCalledWith(expect.objectContaining({
+        prompt: "核心提示词\n\n城市创意\n\n北京专属",
+      }));
+    });
+  });
+
+  it("rebuilds the selected route prompt when retrying a result node", async () => {
+    const seeded = structuredClone(project);
+    const config = seeded.nodes.find((node) => node.id === "config-1")!;
+    config.metadata = {
+      ...config.metadata,
+      composerContent: "",
+      promptRouteSelection: { mode: "route", connectionIds: ["core-concept", "concept-beijing", "beijing-config-1"] },
+    };
+    seeded.nodes.push({
+      id: "result",
+      title: "生成结果",
+      type: CanvasNodeType.Image,
+      position: { x: 1200, y: 40 },
+      width: 360,
+      height: 360,
+      metadata: { status: "error", prompt: "旧提示词" },
+    });
+    seeded.connections.push({ id: "config-result", fromNodeId: "config-1", toNodeId: "result" });
+    useCanvasStore.setState({ hydrated: true, projects: [seeded] });
+
+    render(<CanvasEditor projectId={project.id} onBack={() => undefined} onRequireApiKey={() => undefined} showToast={() => undefined} />);
+    fireEvent.click(screen.getByRole("button", { name: "重新生成" }));
+
+    await waitFor(() => {
+      expect(submitNodeGenerationMock).toHaveBeenCalledWith(expect.objectContaining({
+        prompt: "核心提示词\n\n城市创意\n\n北京专属",
+      }));
+    });
+  });
+});

--- a/frontend/src/components/canvas/__tests__/CanvasEditor.routes.test.tsx
+++ b/frontend/src/components/canvas/__tests__/CanvasEditor.routes.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { CanvasEditor } from "../CanvasEditor";
@@ -104,6 +104,46 @@ describe("CanvasEditor prompt routes", () => {
         connectionIds: ["core-concept", "concept-beijing", "beijing-config-1"],
       });
     });
+  });
+
+  it("renames a node inline and refreshes route labels", async () => {
+    const seeded = structuredClone(project);
+    const core = seeded.nodes.find((node) => node.id === "core")!;
+    core.title = "文本";
+    useCanvasStore.setState({ hydrated: true, projects: [seeded] });
+
+    const { container } = render(
+      <CanvasEditor projectId={project.id} onBack={() => undefined} onRequireApiKey={() => undefined} showToast={() => undefined} />,
+    );
+    const coreNode = container.querySelector('[data-node-id="core"]')!;
+    const getTitleHeader = () => within(coreNode as HTMLElement).getByTitle("双击重命名节点");
+
+    fireEvent.doubleClick(getTitleHeader());
+    const titleInput = within(coreNode as HTMLElement).getByRole("textbox", { name: "节点标题" });
+    fireEvent.change(titleInput, { target: { value: "  核心提示词  " } });
+    fireEvent.keyDown(titleInput, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(getTitleHeader()).toHaveTextContent("核心提示词");
+      expect(useCanvasStore.getState().openProject(project.id)?.nodes.find((node) => node.id === "core")?.title).toBe("核心提示词");
+    });
+
+    const select = screen.getByRole("combobox", { name: "提示词路线" });
+    fireEvent.click(select);
+    expect(await screen.findByRole("option", { name: "核心提示词 -> 城市创意 -> 北京专属" })).toBeInTheDocument();
+    fireEvent.keyDown(select, { key: "Escape" });
+
+    fireEvent.doubleClick(getTitleHeader());
+    const cancelledInput = within(coreNode as HTMLElement).getByRole("textbox", { name: "节点标题" });
+    fireEvent.change(cancelledInput, { target: { value: "取消后的标题" } });
+    fireEvent.keyDown(cancelledInput, { key: "Escape" });
+    expect(getTitleHeader()).toHaveTextContent("核心提示词");
+
+    fireEvent.doubleClick(getTitleHeader());
+    const emptyInput = within(coreNode as HTMLElement).getByRole("textbox", { name: "节点标题" });
+    fireEvent.change(emptyInput, { target: { value: "   " } });
+    fireEvent.blur(emptyInput);
+    expect(getTitleHeader()).toHaveTextContent("核心提示词");
   });
 
   it("highlights the selected config route", () => {

--- a/frontend/src/components/canvas/__tests__/CanvasEditor.routes.test.tsx
+++ b/frontend/src/components/canvas/__tests__/CanvasEditor.routes.test.tsx
@@ -181,6 +181,29 @@ describe("CanvasEditor prompt routes", () => {
     expect(getTitleHeader()).toHaveTextContent("核心提示词");
   });
 
+  it("saves an inline node rename when the blank canvas is pressed", async () => {
+    const { container } = render(
+      <CanvasEditor projectId={project.id} onBack={() => undefined} onRequireApiKey={() => undefined} showToast={() => undefined} />,
+    );
+    const coreNode = container.querySelector('[data-node-id="core"]')!;
+    fireEvent.doubleClick(within(coreNode as HTMLElement).getByTitle("双击重命名节点"));
+    const titleInput = within(coreNode as HTMLElement).getByRole("textbox", { name: "节点标题" });
+    fireEvent.change(titleInput, { target: { value: "画布点击后保存" } });
+
+    const canvas = container.querySelector('[data-canvas-mode="select"]') as HTMLElement & { setPointerCapture: (pointerId: number) => void };
+    canvas.setPointerCapture = vi.fn();
+    fireEvent.pointerDown(canvas, {
+      button: 0,
+      pointerId: 1,
+      clientX: 1200,
+      clientY: 700,
+    });
+
+    await waitFor(() => {
+      expect(useCanvasStore.getState().openProject(project.id)?.nodes.find((node) => node.id === "core")?.title).toBe("画布点击后保存");
+    });
+  });
+
   it("undoes an inline node rename as one edit", async () => {
     const { container } = render(
       <CanvasEditor projectId={project.id} onBack={() => undefined} onRequireApiKey={() => undefined} showToast={() => undefined} />,

--- a/frontend/src/components/canvas/components/__tests__/canvas-node-generation.test.ts
+++ b/frontend/src/components/canvas/components/__tests__/canvas-node-generation.test.ts
@@ -110,4 +110,26 @@ describe("buildNodeGenerationContext prompt routes", () => {
     expect(context.prompt).toBe("使用 【文本1】\n\n【文本1】\n北京内容");
     expect(context.routeValid).toBe(true);
   });
+
+  it("automatically includes the previous generated image for a downstream config", () => {
+    const nodes = [
+      node("original", CanvasNodeType.Image, "原始图片", { content: "data:image/png;base64,original" }),
+      node("first-config", CanvasNodeType.Config, "首次生成", { composerContent: "首次生成" }),
+      node("generated", CanvasNodeType.Image, "首次生成 - 结果 1", { content: "data:image/png;base64,generated" }),
+      node("second-config", CanvasNodeType.Config, "继续修改", {
+        composerContent: "把天空改成傍晚",
+        promptRouteSelection: { mode: "manual" },
+      }),
+    ];
+    const connections = [
+      edge("original-first", "original", "first-config"),
+      edge("first-generated", "first-config", "generated"),
+      edge("generated-second", "generated", "second-config"),
+    ];
+
+    const context = buildNodeGenerationContext("second-config", nodes, connections, "把天空改成傍晚");
+
+    expect(context.referenceImages.map((image) => image.id)).toEqual(["generated"]);
+    expect(context.imageCount).toBe(1);
+  });
 });

--- a/frontend/src/components/canvas/components/__tests__/canvas-node-generation.test.ts
+++ b/frontend/src/components/canvas/components/__tests__/canvas-node-generation.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+
+import { CanvasNodeType, type CanvasConnection, type CanvasNodeData } from "../../types";
+import { buildNodeGenerationContext } from "../canvas-node-generation";
+
+function node(
+  id: string,
+  type: CanvasNodeType,
+  title: string,
+  metadata: CanvasNodeData["metadata"] = {},
+): CanvasNodeData {
+  return { id, type, title, metadata, position: { x: 0, y: 0 }, width: 240, height: 160 };
+}
+
+function edge(id: string, fromNodeId: string, toNodeId: string): CanvasConnection {
+  return { id, fromNodeId, toNodeId };
+}
+
+describe("buildNodeGenerationContext prompt routes", () => {
+  it("joins selected route text before the config supplement", () => {
+    const nodes = [
+      node("core", CanvasNodeType.Text, "核心提示词", { content: "核心提示词" }),
+      node("concept", CanvasNodeType.Text, "城市创意", { content: "城市创意" }),
+      node("beijing", CanvasNodeType.Text, "北京专属", { content: "北京专属" }),
+      node("config", CanvasNodeType.Config, "北京生成配置", {
+        composerContent: "胶片海报质感",
+        promptRouteSelection: { mode: "route", connectionIds: ["core-concept", "concept-beijing", "beijing-config"] },
+      }),
+    ];
+    const connections = [
+      edge("core-concept", "core", "concept"),
+      edge("concept-beijing", "concept", "beijing"),
+      edge("core-beijing", "core", "beijing"),
+      edge("beijing-config", "beijing", "config"),
+    ];
+
+    const context = buildNodeGenerationContext("config", nodes, connections, "胶片海报质感");
+
+    expect(context.prompt).toBe("核心提示词\n\n城市创意\n\n北京专属\n\n胶片海报质感");
+    expect(context.textCount).toBe(3);
+    expect(context.routeValid).toBe(true);
+    expect(context.route?.connectionIds).toEqual(["core-concept", "concept-beijing", "beijing-config"]);
+  });
+
+  it("omits empty route text blocks", () => {
+    const nodes = [
+      node("empty", CanvasNodeType.Text, "空节点", { content: "   " }),
+      node("city", CanvasNodeType.Text, "城市", { content: "北京" }),
+      node("config", CanvasNodeType.Config, "配置", {
+        promptRouteSelection: { mode: "route", connectionIds: ["empty-city", "city-config"] },
+      }),
+    ];
+    const connections = [edge("empty-city", "empty", "city"), edge("city-config", "city", "config")];
+
+    expect(buildNodeGenerationContext("config", nodes, connections, "").prompt).toBe("北京");
+  });
+
+  it("deduplicates route text mentions and includes referenced images", () => {
+    const nodes = [
+      node("core", CanvasNodeType.Text, "核心提示词", { content: "核心内容" }),
+      node("city", CanvasNodeType.Text, "北京专属", { content: "北京内容" }),
+      node("image", CanvasNodeType.Image, "参考图", { content: "data:image/png;base64,abc", mimeType: "image/png" }),
+      node("config", CanvasNodeType.Config, "配置", {
+        composerContent: "结合 @[node:city] 和 @[node:image]",
+        promptRouteSelection: { mode: "route", connectionIds: ["core-city", "city-config"] },
+      }),
+    ];
+    const connections = [
+      edge("core-city", "core", "city"),
+      edge("city-config", "city", "config"),
+      edge("image-config", "image", "config"),
+    ];
+
+    const context = buildNodeGenerationContext("config", nodes, connections, "结合 @[node:city] 和 @[node:image]");
+
+    expect(context.prompt).toBe("核心内容\n\n北京内容\n\n结合 北京专属 和 图片1");
+    expect(context.prompt.match(/北京内容/g)).toHaveLength(1);
+    expect(context.referenceImages.map((image) => image.id)).toEqual(["image"]);
+  });
+
+  it("marks a stale selected route invalid without falling back", () => {
+    const nodes = [
+      node("city", CanvasNodeType.Text, "北京", { content: "北京内容" }),
+      node("config", CanvasNodeType.Config, "配置", {
+        composerContent: "补充",
+        promptRouteSelection: { mode: "route", connectionIds: ["missing"] },
+      }),
+    ];
+    const connections = [edge("city-config", "city", "config")];
+
+    const context = buildNodeGenerationContext("config", nodes, connections, "补充");
+
+    expect(context.routeValid).toBe(false);
+    expect(context.prompt).toBe("补充");
+    expect(context.route).toBeUndefined();
+  });
+
+  it("preserves manual composer behavior", () => {
+    const nodes = [
+      node("city", CanvasNodeType.Text, "北京", { content: "北京内容" }),
+      node("config", CanvasNodeType.Config, "配置", {
+        composerContent: "使用 @[node:city]",
+        promptRouteSelection: { mode: "manual" },
+      }),
+    ];
+    const connections = [edge("city-config", "city", "config")];
+
+    const context = buildNodeGenerationContext("config", nodes, connections, "使用 @[node:city]");
+
+    expect(context.prompt).toBe("使用 【文本1】\n\n【文本1】\n北京内容");
+    expect(context.routeValid).toBe(true);
+  });
+});

--- a/frontend/src/components/canvas/components/canvas-config-node-panel.tsx
+++ b/frontend/src/components/canvas/components/canvas-config-node-panel.tsx
@@ -3,6 +3,7 @@
 import { Lock, LockOpen, Sparkles, Wand2 } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
+import { Select } from "@/components/ui/select";
 import { GenerationParamsBar, type GenerationParamsValue } from "@/components/GenerationParamsBar";
 import { cn } from "@/lib/utils";
 import { normalizeModel } from "@/lib/model-capabilities";
@@ -11,6 +12,8 @@ import { Spinner } from "./canvas-ui";
 import type { CanvasGenerationConfig } from "../types";
 import type { CanvasResourceReference } from "../utils/canvas-resource-references";
 
+export type CanvasPromptRouteOption = { value: string; label: string; disabled?: boolean };
+
 /** 渲染在「编排节点」内部：提示词（@ 引用）+ 模型参数（复用宿主 GenerationParamsBar，含自定义分辨率）+ 生成按钮。 */
 export function CanvasConfigNodePanel({
   prompt,
@@ -18,11 +21,16 @@ export function CanvasConfigNodePanel({
   config,
   lockResultNodes,
   referenceLimit,
+  routeValue,
+  routeOptions,
+  routeInvalid,
+  routesTruncated,
   busy,
   optimizing,
   onPromptChange,
   onConfigChange,
   onToggleLock,
+  onRouteChange,
   onSelect,
   onOptimizePrompt,
   onGenerate,
@@ -32,11 +40,16 @@ export function CanvasConfigNodePanel({
   config: CanvasGenerationConfig;
   lockResultNodes: boolean;
   referenceLimit: { imageCount: number; max: number; exceeded: boolean };
+  routeValue: string;
+  routeOptions: CanvasPromptRouteOption[];
+  routeInvalid: boolean;
+  routesTruncated: boolean;
   busy: boolean;
   optimizing: boolean;
   onPromptChange: (value: string) => void;
   onConfigChange: (patch: Partial<CanvasGenerationConfig>) => void;
   onToggleLock: () => void;
+  onRouteChange: (value: string) => void;
   onSelect: () => void;
   onOptimizePrompt: () => void;
   onGenerate: () => void;
@@ -69,6 +82,18 @@ export function CanvasConfigNodePanel({
 
   return (
     <div className="flex h-full flex-col gap-2 p-2 text-xs" onPointerDown={() => onSelect()}>
+      <div className="shrink-0 space-y-1" data-no-drag>
+        <Select<string>
+          value={routeValue}
+          onValueChange={onRouteChange}
+          options={routeOptions}
+          ariaLabel="提示词路线"
+          size="sm"
+          className={cn("text-xs", routeInvalid && "border-destructive text-destructive")}
+          contentClassName="max-w-[32rem]"
+        />
+        {routesTruncated && <p className="text-[10px] text-muted-foreground">仅显示前 100 条路线</p>}
+      </div>
       <div className="min-h-0 flex-1 cursor-text overflow-auto rounded-lg border border-input bg-background p-1.5" data-no-drag>
         <CanvasMentionEditor value={prompt} references={references} onChange={onPromptChange} placeholder="提示词，输入 @ 引用上游节点…" className="min-h-[56px] text-xs" />
       </div>
@@ -100,7 +125,7 @@ export function CanvasConfigNodePanel({
             {lockResultNodes ? <Lock className="size-3" /> : <LockOpen className="size-3" />}
             <span className="text-[11px]">{lockResultNodes ? "将覆盖已有结果节点" : "将新建结果节点"}</span>
           </Button>
-          <Button size="sm" onClick={onGenerate} disabled={busy || referenceLimit.exceeded} className="flex-1">
+          <Button size="sm" onClick={onGenerate} disabled={busy || routeInvalid || referenceLimit.exceeded} className="flex-1">
             {busy ? <Spinner className="size-4" /> : <Sparkles className="size-4" />}
             生成
           </Button>

--- a/frontend/src/components/canvas/components/canvas-config-node-panel.tsx
+++ b/frontend/src/components/canvas/components/canvas-config-node-panel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Lock, LockOpen, Sparkles, Wand2 } from "lucide-react";
+import { Eye, Lock, LockOpen, Sparkles, Wand2 } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { Select } from "@/components/ui/select";
@@ -33,6 +33,7 @@ export function CanvasConfigNodePanel({
   onRouteChange,
   onSelect,
   onOptimizePrompt,
+  onPreview,
   onGenerate,
 }: {
   prompt: string;
@@ -52,6 +53,7 @@ export function CanvasConfigNodePanel({
   onRouteChange: (value: string) => void;
   onSelect: () => void;
   onOptimizePrompt: () => void;
+  onPreview: () => void;
   onGenerate: () => void;
 }) {
   const value: GenerationParamsValue = {
@@ -105,6 +107,9 @@ export function CanvasConfigNodePanel({
           size="xs"
         />
         <div className="flex items-center gap-1.5">
+          <Button variant="outline" size="xs" onClick={onPreview} className="shrink-0" title="预览最终提示词" aria-label="预览最终提示词">
+            <Eye className="size-3.5" />
+          </Button>
           <Button
             variant="outline"
             size="xs"
@@ -112,6 +117,7 @@ export function CanvasConfigNodePanel({
             disabled={busy || optimizing || !prompt.trim()}
             className="shrink-0 gap-1"
             title="优化提示词（结合连接的上游图片/文字）"
+            aria-label="优化提示词"
           >
             {optimizing ? <Spinner className="size-3.5" /> : <Wand2 className="size-3.5" />}
           </Button>

--- a/frontend/src/components/canvas/components/canvas-connections.tsx
+++ b/frontend/src/components/canvas/components/canvas-connections.tsx
@@ -8,6 +8,7 @@ export function ConnectionPath({
   from,
   to,
   active,
+  routeActive = false,
   onSelect,
   onContextMenu,
 }: {
@@ -15,6 +16,7 @@ export function ConnectionPath({
   from: CanvasNodeData;
   to: CanvasNodeData;
   active: boolean;
+  routeActive?: boolean;
   onSelect: () => void;
   onContextMenu?: (event: ReactMouseEvent<SVGPathElement>) => void;
 }) {
@@ -31,6 +33,7 @@ export function ConnectionPath({
     <g>
       <path
         data-connection-id={connection.id}
+        data-route-active={routeActive || undefined}
         d={pathD}
         stroke="transparent"
         strokeWidth="16"
@@ -48,11 +51,11 @@ export function ConnectionPath({
       />
       <path
         d={pathD}
-        stroke={active ? theme.node.activeStroke : theme.node.muted}
-        strokeWidth={active ? 3 : 2}
-        strokeOpacity={active ? 1 : 0.82}
+        stroke={active || routeActive ? theme.node.activeStroke : theme.node.muted}
+        strokeWidth={active || routeActive ? 3 : 2}
+        strokeOpacity={active || routeActive ? 1 : 0.82}
         fill="none"
-        style={{ filter: active ? `drop-shadow(0 0 8px color-mix(in srgb, ${theme.node.activeStroke} 40%, transparent))` : undefined, pointerEvents: "none" }}
+        style={{ filter: active || routeActive ? `drop-shadow(0 0 8px color-mix(in srgb, ${theme.node.activeStroke} 40%, transparent))` : undefined, pointerEvents: "none" }}
       />
     </g>
   );

--- a/frontend/src/components/canvas/components/canvas-context-menu.tsx
+++ b/frontend/src/components/canvas/components/canvas-context-menu.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect } from "react";
 import { createPortal } from "react-dom";
-import { Copy, Crop, Eraser, Grid3x3, Maximize2, PaintBucket, RefreshCw, Rotate3d, Sparkles, Text, Trash2, Type } from "lucide-react";
+import { Copy, Crop, Eraser, FileText, Grid3x3, Image as ImageIcon, Maximize2, PaintBucket, RefreshCw, Rotate3d, Settings2, Sparkles, Square, Text, Trash2, Type } from "lucide-react";
 
 import { CanvasNodeType, type CanvasNodeData, type ContextMenuState } from "../types";
 
@@ -21,6 +21,9 @@ export type CanvasContextMenuActions = {
   onAiGenerateText?: (prompt: string) => void;
   onAnnotationChangeColor?: () => void;
   onAnnotationChangeFontSize?: () => void;
+  onAddNodeAt?: (type: CanvasNodeType) => void;
+  onPasteAt?: () => void;
+  canPaste?: boolean;
 };
 
 export function CanvasContextMenu({ state, node, onClose, actions }: { state: ContextMenuState | null; node?: CanvasNodeData; onClose: () => void; actions: CanvasContextMenuActions }) {
@@ -45,7 +48,13 @@ export function CanvasContextMenu({ state, node, onClose, actions }: { state: Co
   const isAnnotation = state.type === "node" && node?.type === CanvasNodeType.TextAnnotation;
 
   const items: { label: string; icon: React.ReactNode; onClick: () => void; danger?: boolean }[] = [];
-  if (state.type === "connection") {
+  if (state.type === "canvas") {
+    items.push({ label: "在此添加图片节点", icon: <ImageIcon className="size-4" />, onClick: () => actions.onAddNodeAt?.(CanvasNodeType.Image) });
+    items.push({ label: "在此添加文本节点", icon: <FileText className="size-4" />, onClick: () => actions.onAddNodeAt?.(CanvasNodeType.Text) });
+    items.push({ label: "在此添加生成配置", icon: <Settings2 className="size-4" />, onClick: () => actions.onAddNodeAt?.(CanvasNodeType.Config) });
+    items.push({ label: "在此添加注释", icon: <Square className="size-4" />, onClick: () => actions.onAddNodeAt?.(CanvasNodeType.TextAnnotation) });
+    if (actions.canPaste && actions.onPasteAt) items.push({ label: "粘贴到此处", icon: <Copy className="size-4" />, onClick: actions.onPasteAt });
+  } else if (state.type === "connection") {
     items.push({ label: "删除连线", icon: <Trash2 className="size-4" />, onClick: actions.onDeleteConnection, danger: true });
   } else {
     if (canGenerate) items.push({ label: "生成", icon: <Sparkles className="size-4" />, onClick: actions.onGenerate });

--- a/frontend/src/components/canvas/components/canvas-generation-preview-dialog.tsx
+++ b/frontend/src/components/canvas/components/canvas-generation-preview-dialog.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { Copy, Image as ImageIcon, Route, Settings2 } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import type { NodeGenerationContext } from "./canvas-node-generation";
+import type { CanvasGenerationConfig, CanvasNodeData } from "../types";
+
+export function CanvasGenerationPreviewDialog({
+  open,
+  onOpenChange,
+  node,
+  context,
+  config,
+  onCopy,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  node: CanvasNodeData | null;
+  context: NodeGenerationContext | null;
+  config: CanvasGenerationConfig | null;
+  onCopy: (text: string) => void;
+}) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>生成预览</DialogTitle>
+        </DialogHeader>
+        {node && context && config && (
+          <div className="space-y-4">
+            <div className="grid grid-cols-1 gap-2 text-xs sm:grid-cols-3">
+              <PreviewMeta icon={<Route />} label="提示词路线" value={context.route?.label || "手动编排"} />
+              <PreviewMeta icon={<ImageIcon />} label="引用资源" value={`${context.textCount} 段文本 / ${context.imageCount} 张图片`} />
+              <PreviewMeta icon={<Settings2 />} label="生成参数" value={`${config.model} · ${config.outputSize} · ${config.aspectRatio} · ${config.count} 张`} />
+            </div>
+            <div>
+              <div className="mb-1.5 flex items-center justify-between gap-2">
+                <span className="text-sm font-medium">{node.title} · 最终提示词</span>
+                <Button variant="outline" size="xs" onClick={() => onCopy(context.prompt)}>
+                  <Copy className="size-3.5" />
+                  复制
+                </Button>
+              </div>
+              <pre className="max-h-[50vh] overflow-auto whitespace-pre-wrap rounded-md border border-border bg-muted/40 p-3 text-xs leading-relaxed">{context.prompt || "（提示词为空）"}</pre>
+            </div>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export type CanvasBatchPreviewItem = {
+  node: CanvasNodeData;
+  valid: boolean;
+  reason?: string;
+  imageCount: number;
+};
+
+export function CanvasBatchGenerationDialog({
+  open,
+  onOpenChange,
+  items,
+  onConfirm,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  items: CanvasBatchPreviewItem[];
+  onConfirm: () => void;
+}) {
+  const validItems = items.filter((item) => item.valid);
+  const totalImages = validItems.reduce((sum, item) => sum + item.imageCount, 0);
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>批量生成</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-3">
+          <p className="text-sm">已选择 {items.length} 个配置，其中 {validItems.length} 个可生成，预计生成 {totalImages} 张图片。</p>
+          <div className="max-h-64 space-y-1 overflow-auto rounded-md border border-border p-2">
+            {items.map((item) => (
+              <div key={item.node.id} className="flex items-center justify-between gap-3 rounded px-2 py-1.5 text-xs">
+                <span className="min-w-0 truncate font-medium">{item.node.title}</span>
+                <span className={item.valid ? "shrink-0 text-muted-foreground" : "shrink-0 text-destructive"}>{item.valid ? `${item.imageCount} 张` : item.reason}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>取消</Button>
+          <Button disabled={!validItems.length} onClick={onConfirm}>开始生成 {validItems.length} 个配置</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function PreviewMeta({ icon, label, value }: { icon: React.ReactNode; label: string; value: string }) {
+  return (
+    <div className="min-w-0 rounded-md border border-border p-2">
+      <span className="mb-1 flex items-center gap-1 text-muted-foreground [&_svg]:size-3.5">{icon}{label}</span>
+      <span className="block truncate font-medium" title={value}>{value}</span>
+    </div>
+  );
+}

--- a/frontend/src/components/canvas/components/canvas-node-generation.ts
+++ b/frontend/src/components/canvas/components/canvas-node-generation.ts
@@ -1,6 +1,11 @@
 import { imageReferenceLabel } from "../lib/image-reference-prompt";
 import type { ReferenceImage } from "../types-media";
 import { CanvasNodeType, type CanvasConnection, type CanvasNodeData } from "../types";
+import {
+  enumeratePromptRoutes,
+  findSelectedPromptRoute,
+  type CanvasPromptRoute,
+} from "../lib/canvas-prompt-routes";
 import { getGenerationResourceNodes } from "../utils/canvas-resource-references";
 
 export type NodeGenerationContext = {
@@ -8,6 +13,8 @@ export type NodeGenerationContext = {
   referenceImages: ReferenceImage[];
   textCount: number;
   imageCount: number;
+  routeValid: boolean;
+  route?: CanvasPromptRoute;
 };
 
 export type NodeGenerationInput = {
@@ -21,6 +28,21 @@ export type NodeGenerationInput = {
 export function buildNodeGenerationContext(nodeId: string, nodes: CanvasNodeData[], connections: CanvasConnection[], prompt: string): NodeGenerationContext {
   const inputs = buildNodeGenerationInputs(nodeId, nodes, connections);
   const sourceNode = nodes.find((node) => node.id === nodeId);
+  const routeSelection = sourceNode?.metadata?.promptRouteSelection;
+  if (sourceNode?.type === CanvasNodeType.Config && routeSelection?.mode === "route") {
+    const routes = enumeratePromptRoutes(nodeId, nodes, connections).routes;
+    const route = findSelectedPromptRoute(routeSelection, routes);
+    if (!route) {
+      return {
+        prompt,
+        referenceImages: [],
+        textCount: 0,
+        imageCount: 0,
+        routeValid: false,
+      };
+    }
+    return buildRouteGenerationContext(route, nodes, inputs, prompt);
+  }
   if (sourceNode?.type === CanvasNodeType.Config && Boolean(sourceNode.metadata?.composerContent?.trim())) {
     return buildComposerGenerationContext(inputs, prompt);
   }
@@ -36,6 +58,82 @@ export function buildNodeGenerationContext(nodeId: string, nodes: CanvasNodeData
     referenceImages,
     textCount: inputs.filter((input) => input.type === "text").length,
     imageCount: referenceImages.length,
+    routeValid: true,
+  };
+}
+
+function buildRouteGenerationContext(
+  route: CanvasPromptRoute,
+  nodes: CanvasNodeData[],
+  directInputs: NodeGenerationInput[],
+  supplement: string,
+): NodeGenerationContext {
+  const nodeById = new Map(nodes.map((node) => [node.id, node]));
+  const routeTextIds = new Set(route.nodeIds);
+  const routeInputs = route.nodeIds.flatMap((nodeId): NodeGenerationInput[] => {
+    const node = nodeById.get(nodeId);
+    if (!node) return [];
+    const text = readNodeTextInput(node);
+    return text ? [{ nodeId, type: "text", title: node.title, text }] : [];
+  });
+  const inputByNodeId = new Map([...directInputs, ...routeInputs].map((input) => [input.nodeId, input]));
+  const routeBlocks = routeInputs.map((input) => input.text?.trim()).filter((text): text is string => Boolean(text));
+  const additionalTextBlocks: string[] = [];
+  const selectedImages: NodeGenerationInput[] = [];
+  const labelByNodeId = new Map<string, string>();
+  const selectedAdditionalTextIds = new Set<string>();
+  const selectedImageIds = new Set<string>();
+  let lastIndex = 0;
+  let resolvedSupplement = "";
+
+  for (const match of supplement.matchAll(/@\[node:([^\]]+)\]/g)) {
+    if (match.index === undefined) continue;
+    resolvedSupplement += supplement.slice(lastIndex, match.index);
+    const input = inputByNodeId.get(match[1]);
+    if (input) {
+      if (input.type === "text" && routeTextIds.has(input.nodeId)) {
+        resolvedSupplement += input.title;
+      } else {
+        let label = labelByNodeId.get(input.nodeId);
+        if (!label) {
+          if (input.type === "image") {
+            label = imageReferenceLabel(selectedImages.length);
+            if (!selectedImageIds.has(input.nodeId)) {
+              selectedImageIds.add(input.nodeId);
+              selectedImages.push(input);
+            }
+          } else {
+            label = `文本${additionalTextBlocks.length + 1}`;
+            if (!selectedAdditionalTextIds.has(input.nodeId)) {
+              selectedAdditionalTextIds.add(input.nodeId);
+              additionalTextBlocks.push(`【${label}】\n${input.text || ""}`);
+            }
+          }
+          labelByNodeId.set(input.nodeId, label);
+        }
+        resolvedSupplement += input.type === "text" ? `【${label}】` : label;
+      }
+    }
+    lastIndex = match.index + match[0].length;
+  }
+  resolvedSupplement += supplement.slice(lastIndex);
+
+  const referenceImages = selectedImages
+    .map((input) => input.image)
+    .filter((image): image is ReferenceImage => Boolean(image));
+  const promptBlocks = [
+    ...routeBlocks,
+    resolvedSupplement.trim(),
+    ...additionalTextBlocks,
+  ].filter(Boolean);
+
+  return {
+    prompt: promptBlocks.join("\n\n"),
+    referenceImages,
+    textCount: routeBlocks.length + additionalTextBlocks.length,
+    imageCount: referenceImages.length,
+    routeValid: true,
+    route,
   };
 }
 
@@ -77,6 +175,7 @@ function buildComposerGenerationContext(inputs: NodeGenerationInput[], prompt: s
       referenceImages: [],
       textCount: 0,
       imageCount: 0,
+      routeValid: true,
     };
   }
 
@@ -85,6 +184,7 @@ function buildComposerGenerationContext(inputs: NodeGenerationInput[], prompt: s
     referenceImages,
     textCount: counts.text,
     imageCount: referenceImages.length,
+    routeValid: true,
   };
 }
 

--- a/frontend/src/components/canvas/components/canvas-node-generation.ts
+++ b/frontend/src/components/canvas/components/canvas-node-generation.ts
@@ -79,10 +79,11 @@ function buildRouteGenerationContext(
   const inputByNodeId = new Map([...directInputs, ...routeInputs].map((input) => [input.nodeId, input]));
   const routeBlocks = routeInputs.map((input) => input.text?.trim()).filter((text): text is string => Boolean(text));
   const additionalTextBlocks: string[] = [];
-  const selectedImages: NodeGenerationInput[] = [];
+  const selectedImages = directInputs.filter((input) => input.type === "image");
   const labelByNodeId = new Map<string, string>();
   const selectedAdditionalTextIds = new Set<string>();
-  const selectedImageIds = new Set<string>();
+  const selectedImageIds = new Set(selectedImages.map((input) => input.nodeId));
+  selectedImages.forEach((input, index) => labelByNodeId.set(input.nodeId, imageReferenceLabel(index)));
   let lastIndex = 0;
   let resolvedSupplement = "";
 
@@ -139,10 +140,11 @@ function buildRouteGenerationContext(
 
 function buildComposerGenerationContext(inputs: NodeGenerationInput[], prompt: string): NodeGenerationContext {
   const inputByNodeId = new Map(inputs.map((input) => [input.nodeId, input]));
-  const selectedInputs: NodeGenerationInput[] = [];
+  const selectedInputs = inputs.filter((input) => input.type === "image");
   const labelByNodeId = new Map<string, string>();
   const textBlocks: string[] = [];
-  const counts = { image: 0, text: 0 };
+  const counts = { image: selectedInputs.length, text: 0 };
+  selectedInputs.forEach((input, index) => labelByNodeId.set(input.nodeId, generationLabel("image", index)));
   let hasToken = false;
   let lastIndex = 0;
   let nextPrompt = "";
@@ -172,9 +174,9 @@ function buildComposerGenerationContext(inputs: NodeGenerationInput[], prompt: s
   if (!hasToken) {
     return {
       prompt,
-      referenceImages: [],
+      referenceImages,
       textCount: 0,
-      imageCount: 0,
+      imageCount: referenceImages.length,
       routeValid: true,
     };
   }

--- a/frontend/src/components/canvas/components/canvas-node-search-dialog.tsx
+++ b/frontend/src/components/canvas/components/canvas-node-search-dialog.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { Search } from "lucide-react";
+import { useMemo, useState } from "react";
+
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { CanvasNodeType, type CanvasNodeData } from "../types";
+
+export function CanvasNodeSearchDialog({ open, onOpenChange, nodes, onSelect }: { open: boolean; onOpenChange: (open: boolean) => void; nodes: CanvasNodeData[]; onSelect: (node: CanvasNodeData) => void }) {
+  const [query, setQuery] = useState("");
+  const results = useMemo(() => {
+    const normalized = query.trim().toLocaleLowerCase("zh-CN");
+    if (!normalized) return nodes.slice(0, 30);
+    return nodes.filter((node) => `${node.title}\n${node.metadata?.content || ""}\n${node.metadata?.composerContent || ""}`.toLocaleLowerCase("zh-CN").includes(normalized)).slice(0, 50);
+  }, [nodes, query]);
+  return (
+    <Dialog open={open} onOpenChange={(next) => { onOpenChange(next); if (!next) setQuery(""); }}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader><DialogTitle>搜索节点</DialogTitle></DialogHeader>
+        <div className="space-y-3">
+          <div className="relative">
+            <Search className="pointer-events-none absolute left-2.5 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+            <Input autoFocus type="search" aria-label="搜索节点" value={query} onChange={(event) => setQuery(event.target.value)} placeholder="输入节点标题或内容" className="pl-8" />
+          </div>
+          <div className="max-h-80 space-y-1 overflow-auto">
+            {results.map((node) => (
+              <button
+                key={node.id}
+                type="button"
+                aria-label={`定位到 ${node.title}`}
+                className="flex w-full items-center justify-between gap-3 rounded-md px-2.5 py-2 text-left hover:bg-muted"
+                onClick={() => { onSelect(node); onOpenChange(false); setQuery(""); }}
+              >
+                <span className="min-w-0">
+                  <span className="block truncate text-sm font-medium">{node.title}</span>
+                  <span className="block truncate text-xs text-muted-foreground">{node.metadata?.content || node.metadata?.composerContent || nodeTypeLabel(node.type)}</span>
+                </span>
+                <span className="shrink-0 text-[11px] text-muted-foreground">{nodeTypeLabel(node.type)}</span>
+              </button>
+            ))}
+            {results.length === 0 && <p className="py-8 text-center text-sm text-muted-foreground">没有匹配的节点</p>}
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function nodeTypeLabel(type: CanvasNodeType) {
+  if (type === CanvasNodeType.Image) return "图片";
+  if (type === CanvasNodeType.Config) return "生成配置";
+  if (type === CanvasNodeType.TextAnnotation) return "注释";
+  return "文本";
+}

--- a/frontend/src/components/canvas/components/canvas-node.tsx
+++ b/frontend/src/components/canvas/components/canvas-node.tsx
@@ -95,6 +95,7 @@ export const CanvasNode = React.memo(function CanvasNode({
   return (
     <div
       data-node-id={data.id}
+      data-selected={isSelected || undefined}
       data-route-active={isRouteActive || undefined}
       className="group absolute [&_button]:cursor-pointer"
       style={{ left: data.position.x, top: data.position.y, width: data.width, height: data.height, zIndex }}

--- a/frontend/src/components/canvas/components/canvas-node.tsx
+++ b/frontend/src/components/canvas/components/canvas-node.tsx
@@ -26,6 +26,7 @@ type CanvasNodeProps = {
   imageUrl?: string;
   isSelected: boolean;
   isRelated: boolean;
+  isRouteActive: boolean;
   isConnectionTarget: boolean;
   referenceLimitExceeded?: boolean;
   zIndex: number;
@@ -54,6 +55,7 @@ export const CanvasNode = React.memo(function CanvasNode({
   imageUrl,
   isSelected,
   isRelated,
+  isRouteActive,
   isConnectionTarget,
   referenceLimitExceeded = false,
   zIndex,
@@ -78,16 +80,19 @@ export const CanvasNode = React.memo(function CanvasNode({
 }: CanvasNodeProps) {
   const theme = canvasTheme;
   const status = data.metadata?.status ?? "idle";
-  const borderColor = referenceLimitExceeded ? "var(--destructive)" : isSelected || isConnectionTarget ? theme.node.activeStroke : isRelated ? theme.node.muted : theme.node.stroke;
+  const borderColor = referenceLimitExceeded ? "var(--destructive)" : isSelected || isConnectionTarget || isRouteActive ? theme.node.activeStroke : isRelated ? theme.node.muted : theme.node.stroke;
   const boxShadow = referenceLimitExceeded
     ? "0 0 0 4px color-mix(in srgb, var(--destructive) 18%, transparent)"
     : isSelected
       ? `0 0 0 4px color-mix(in srgb, ${theme.node.activeStroke} 18%, transparent)`
-      : undefined;
+      : isRouteActive
+        ? `0 0 0 3px color-mix(in srgb, ${theme.node.activeStroke} 12%, transparent)`
+        : undefined;
 
   return (
     <div
       data-node-id={data.id}
+      data-route-active={isRouteActive || undefined}
       className="group absolute [&_button]:cursor-pointer"
       style={{ left: data.position.x, top: data.position.y, width: data.width, height: data.height, zIndex }}
       onPointerDown={(event) => onPointerDownNode(event, data.id)}

--- a/frontend/src/components/canvas/components/canvas-node.tsx
+++ b/frontend/src/components/canvas/components/canvas-node.tsx
@@ -36,6 +36,7 @@ type CanvasNodeProps = {
   onContextMenu: (event: React.MouseEvent, nodeId: string) => void;
   onConnectStart: (event: React.PointerEvent, nodeId: string, handleType: "source" | "target") => void;
   onResizeStart: (event: React.PointerEvent, nodeId: string, corner: ResizeCorner) => void;
+  onTitleChange: (nodeId: string, title: string) => void;
   onContentChange: (nodeId: string, content: string) => void;
   onUploadToNode?: (nodeId: string) => void;
   onImportToNode?: (nodeId: string) => void;
@@ -65,6 +66,7 @@ export const CanvasNode = React.memo(function CanvasNode({
   onContextMenu,
   onConnectStart,
   onResizeStart,
+  onTitleChange,
   onContentChange,
   onUploadToNode,
   onImportToNode,
@@ -78,6 +80,7 @@ export const CanvasNode = React.memo(function CanvasNode({
   onToggleRenderMode,
   renderPanel,
 }: CanvasNodeProps) {
+  const [titleDraft, setTitleDraft] = useState<string | null>(null);
   const theme = canvasTheme;
   const status = data.metadata?.status ?? "idle";
   const borderColor = referenceLimitExceeded ? "var(--destructive)" : isSelected || isConnectionTarget || isRouteActive ? theme.node.activeStroke : isRelated ? theme.node.muted : theme.node.stroke;
@@ -102,8 +105,47 @@ export const CanvasNode = React.memo(function CanvasNode({
         className="relative flex h-full w-full flex-col overflow-hidden rounded-2xl border-2 shadow-sm transition-[border-color,box-shadow]"
         style={{ borderColor, background: theme.node.fill, boxShadow }}
       >
-        <div className="flex items-center gap-2 px-2.5 py-1.5 text-[11px] font-medium" style={{ color: theme.node.label }}>
-          <span className="truncate">{data.title}</span>
+        <div
+          className="flex min-h-7 items-center gap-2 px-2.5 py-1 text-[11px] font-medium"
+          style={{ color: theme.node.label }}
+          onDoubleClick={(event) => {
+            event.stopPropagation();
+            setTitleDraft(data.title);
+          }}
+          title={titleDraft === null ? "双击重命名节点" : undefined}
+        >
+          {titleDraft === null ? (
+            <span className="truncate">{data.title}</span>
+          ) : (
+            <input
+              autoFocus
+              aria-label="节点标题"
+              data-canvas-no-zoom="true"
+              value={titleDraft}
+              onFocus={(event) => event.currentTarget.select()}
+              onChange={(event) => setTitleDraft(event.target.value)}
+              onPointerDown={(event) => event.stopPropagation()}
+              onDoubleClick={(event) => event.stopPropagation()}
+              onBlur={() => {
+                const nextTitle = titleDraft.trim();
+                setTitleDraft(null);
+                if (nextTitle && nextTitle !== data.title) onTitleChange(data.id, nextTitle);
+              }}
+              onKeyDown={(event) => {
+                event.stopPropagation();
+                if (event.key === "Enter") {
+                  event.preventDefault();
+                  const nextTitle = titleDraft.trim();
+                  setTitleDraft(null);
+                  if (nextTitle && nextTitle !== data.title) onTitleChange(data.id, nextTitle);
+                } else if (event.key === "Escape") {
+                  event.preventDefault();
+                  setTitleDraft(null);
+                }
+              }}
+              className="h-5 min-w-0 flex-1 rounded border border-input bg-background px-1.5 text-[11px] font-medium text-foreground outline-none focus:border-ring focus:ring-1 focus:ring-ring/40"
+            />
+          )}
         </div>
 
         <div className="relative min-h-0 flex-1">

--- a/frontend/src/components/canvas/components/canvas-toolbar.tsx
+++ b/frontend/src/components/canvas/components/canvas-toolbar.tsx
@@ -1,11 +1,13 @@
 "use client";
 
-import { AlignCenterHorizontal, AlignCenterVertical, AlignEndHorizontal, AlignEndVertical, AlignStartHorizontal, AlignStartVertical, BetweenHorizontalStart, BetweenVerticalStart, CircleDot, Columns3, Grid2x2, Image as ImageIcon, Info, LayoutDashboard, LibraryBig, Redo2, Rows3, Search, Settings2, SlidersHorizontal, Sparkles, Square, Trash2, Type, Undo2, Workflow } from "lucide-react";
+import { AlignCenterHorizontal, AlignCenterVertical, AlignEndHorizontal, AlignEndVertical, AlignStartHorizontal, AlignStartVertical, BetweenHorizontalStart, BetweenVerticalStart, CircleDot, Columns3, Grid2x2, Hand, Image as ImageIcon, Info, LayoutDashboard, LibraryBig, MousePointer2, Redo2, Rows3, Search, Settings2, SlidersHorizontal, Sparkles, Square, Trash2, Type, Undo2, Workflow } from "lucide-react";
 
 import { Button, buttonVariants } from "@/components/ui/button";
 import { DropdownMenu, DropdownMenuCheckboxItem, DropdownMenuContent, DropdownMenuGroup, DropdownMenuItem, DropdownMenuLabel, DropdownMenuRadioGroup, DropdownMenuRadioItem, DropdownMenuSeparator, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
+import { Segmented } from "@/components/ui/toggle-group";
 import { cn } from "@/lib/utils";
 import type { CanvasBackgroundMode } from "../lib/canvas-theme";
+import type { CanvasInteractionMode } from "../types";
 import type { CanvasArrangeMode } from "../utils/canvas-layout";
 import { CanvasTooltip } from "./canvas-ui";
 
@@ -17,6 +19,7 @@ type CanvasToolbarProps = {
   canRedo: boolean;
   backgroundMode: CanvasBackgroundMode;
   showImageInfo: boolean;
+  interactionMode: CanvasInteractionMode;
   showPromptGallery?: boolean;
   onAddImage: () => void;
   onAddText: () => void;
@@ -32,6 +35,7 @@ type CanvasToolbarProps = {
   onSearch: () => void;
   onBackgroundModeChange: (mode: CanvasBackgroundMode) => void;
   onShowImageInfoChange: (value: boolean) => void;
+  onInteractionModeChange: (mode: CanvasInteractionMode) => void;
 };
 
 export function CanvasToolbar({
@@ -42,6 +46,7 @@ export function CanvasToolbar({
   canRedo,
   backgroundMode,
   showImageInfo,
+  interactionMode,
   showPromptGallery = true,
   onAddImage,
   onAddText,
@@ -57,6 +62,7 @@ export function CanvasToolbar({
   onSearch,
   onBackgroundModeChange,
   onShowImageInfoChange,
+  onInteractionModeChange,
 }: CanvasToolbarProps) {
   return (
     <div
@@ -64,6 +70,18 @@ export function CanvasToolbar({
       className="absolute top-4 left-1/2 z-50 flex -translate-x-1/2 items-center gap-1 rounded-2xl border border-border bg-card/95 px-2 py-1.5 shadow-lg backdrop-blur"
       onPointerDown={(event) => event.stopPropagation()}
     >
+      <Segmented
+        value={interactionMode}
+        onChange={onInteractionModeChange}
+        options={[
+          { value: "select", icon: <MousePointer2 />, title: "选择模式" },
+          { value: "pan", icon: <Hand />, title: "抓手模式" },
+        ]}
+        className="border-0 bg-transparent p-0"
+      />
+
+      <div className="mx-1 h-5 w-px bg-border" />
+
       <CanvasTooltip label="添加图片节点">
         <Button variant="ghost" size="icon-sm" onClick={onAddImage} aria-label="添加图片节点">
           <ImageIcon className="size-4" />

--- a/frontend/src/components/canvas/components/canvas-toolbar.tsx
+++ b/frontend/src/components/canvas/components/canvas-toolbar.tsx
@@ -1,15 +1,18 @@
 "use client";
 
-import { CircleDot, Grid2x2, Image as ImageIcon, Info, LayoutDashboard, LibraryBig, Redo2, Settings2, Square, Trash2, Type, Undo2 } from "lucide-react";
+import { AlignCenterHorizontal, AlignCenterVertical, AlignEndHorizontal, AlignEndVertical, AlignStartHorizontal, AlignStartVertical, BetweenHorizontalStart, BetweenVerticalStart, CircleDot, Columns3, Grid2x2, Image as ImageIcon, Info, LayoutDashboard, LibraryBig, Redo2, Rows3, Search, Settings2, SlidersHorizontal, Sparkles, Square, Trash2, Type, Undo2, Workflow } from "lucide-react";
 
-import { Button } from "@/components/ui/button";
-import { Segmented } from "@/components/ui/toggle-group";
-import { Switch } from "@/components/ui/switch";
+import { Button, buttonVariants } from "@/components/ui/button";
+import { DropdownMenu, DropdownMenuCheckboxItem, DropdownMenuContent, DropdownMenuGroup, DropdownMenuItem, DropdownMenuLabel, DropdownMenuRadioGroup, DropdownMenuRadioItem, DropdownMenuSeparator, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
+import { cn } from "@/lib/utils";
 import type { CanvasBackgroundMode } from "../lib/canvas-theme";
+import type { CanvasArrangeMode } from "../utils/canvas-layout";
 import { CanvasTooltip } from "./canvas-ui";
 
 type CanvasToolbarProps = {
   selectedCount: number;
+  nodeCount: number;
+  selectedConfigCount: number;
   canUndo: boolean;
   canRedo: boolean;
   backgroundMode: CanvasBackgroundMode;
@@ -24,12 +27,17 @@ type CanvasToolbarProps = {
   onUndo: () => void;
   onRedo: () => void;
   onDelete: () => void;
+  onArrange: (mode: CanvasArrangeMode | "graph") => void;
+  onGenerateSelected: () => void;
+  onSearch: () => void;
   onBackgroundModeChange: (mode: CanvasBackgroundMode) => void;
   onShowImageInfoChange: (value: boolean) => void;
 };
 
 export function CanvasToolbar({
   selectedCount,
+  nodeCount,
+  selectedConfigCount,
   canUndo,
   canRedo,
   backgroundMode,
@@ -44,6 +52,9 @@ export function CanvasToolbar({
   onUndo,
   onRedo,
   onDelete,
+  onArrange,
+  onGenerateSelected,
+  onSearch,
   onBackgroundModeChange,
   onShowImageInfoChange,
 }: CanvasToolbarProps) {
@@ -98,25 +109,78 @@ export function CanvasToolbar({
           <Redo2 className="size-4" />
         </Button>
       </CanvasTooltip>
+      <CanvasTooltip label="搜索节点">
+        <Button variant="ghost" size="icon-sm" onClick={onSearch} aria-label="搜索节点">
+          <Search className="size-4" />
+        </Button>
+      </CanvasTooltip>
+
+      <DropdownMenu>
+        <DropdownMenuTrigger
+          aria-label="排列节点"
+          title="排列节点"
+          disabled={nodeCount < 2}
+          className={cn(buttonVariants({ variant: "ghost", size: "icon-sm" }))}
+        >
+          <AlignStartVertical className="size-4" />
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="center" className="w-48">
+          <DropdownMenuGroup>
+            <DropdownMenuLabel>对齐</DropdownMenuLabel>
+            <ArrangeItem label="左对齐" icon={<AlignStartVertical />} disabled={selectedCount < 2} onClick={() => onArrange("align-left")} />
+            <ArrangeItem label="水平居中" icon={<AlignCenterVertical />} disabled={selectedCount < 2} onClick={() => onArrange("align-center-horizontal")} />
+            <ArrangeItem label="右对齐" icon={<AlignEndVertical />} disabled={selectedCount < 2} onClick={() => onArrange("align-right")} />
+            <ArrangeItem label="顶对齐" icon={<AlignStartHorizontal />} disabled={selectedCount < 2} onClick={() => onArrange("align-top")} />
+            <ArrangeItem label="垂直居中" icon={<AlignCenterHorizontal />} disabled={selectedCount < 2} onClick={() => onArrange("align-center-vertical")} />
+            <ArrangeItem label="底对齐" icon={<AlignEndHorizontal />} disabled={selectedCount < 2} onClick={() => onArrange("align-bottom")} />
+          </DropdownMenuGroup>
+          <DropdownMenuSeparator />
+          <DropdownMenuGroup>
+            <DropdownMenuLabel>分布与排列</DropdownMenuLabel>
+            <ArrangeItem label="水平等距" icon={<BetweenHorizontalStart />} disabled={selectedCount < 3} onClick={() => onArrange("distribute-horizontal")} />
+            <ArrangeItem label="垂直等距" icon={<BetweenVerticalStart />} disabled={selectedCount < 3} onClick={() => onArrange("distribute-vertical")} />
+            <ArrangeItem label="横向排列" icon={<Columns3 />} disabled={selectedCount < 2} onClick={() => onArrange("row")} />
+            <ArrangeItem label="纵向排列" icon={<Rows3 />} disabled={selectedCount < 2} onClick={() => onArrange("column")} />
+            <ArrangeItem label="紧凑网格" icon={<Grid2x2 />} disabled={selectedCount < 2} onClick={() => onArrange("grid")} />
+          </DropdownMenuGroup>
+          <DropdownMenuSeparator />
+          <ArrangeItem label="按链路自动布局" icon={<Workflow />} onClick={() => onArrange("graph")} />
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      {selectedConfigCount > 1 && (
+        <CanvasTooltip label={`生成所选配置（${selectedConfigCount}）`}>
+          <Button variant="ghost" size="icon-sm" onClick={onGenerateSelected} aria-label="生成所选配置">
+            <Sparkles className="size-4" />
+          </Button>
+        </CanvasTooltip>
+      )}
 
       <div className="mx-1 h-5 w-px bg-border" />
 
-      <Segmented
-        value={backgroundMode}
-        onChange={onBackgroundModeChange}
-        options={[
-          { value: "lines", icon: <Grid2x2 />, title: "网格" },
-          { value: "dots", icon: <CircleDot />, title: "圆点" },
-          { value: "blank", icon: <Square />, title: "空白" },
-        ]}
-      />
-
-      <CanvasTooltip label="显示图片信息">
-        <label className="ml-1 flex items-center gap-1 rounded-md px-1.5 py-1 text-xs text-muted-foreground">
-          <Info className="size-3.5" />
-          <Switch checked={showImageInfo} onCheckedChange={onShowImageInfoChange} />
-        </label>
-      </CanvasTooltip>
+      <DropdownMenu>
+        <DropdownMenuTrigger
+          aria-label="画布显示设置"
+          title="画布显示设置"
+          className={cn(buttonVariants({ variant: "ghost", size: "icon-sm" }))}
+        >
+          <SlidersHorizontal className="size-4" />
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="center" className="w-48">
+          <DropdownMenuGroup>
+            <DropdownMenuLabel>画布背景</DropdownMenuLabel>
+            <DropdownMenuRadioGroup value={backgroundMode} onValueChange={(value) => onBackgroundModeChange(value as CanvasBackgroundMode)}>
+              <DropdownMenuRadioItem value="lines"><Grid2x2 />网格背景</DropdownMenuRadioItem>
+              <DropdownMenuRadioItem value="dots"><CircleDot />圆点背景</DropdownMenuRadioItem>
+              <DropdownMenuRadioItem value="blank"><Square />空白背景</DropdownMenuRadioItem>
+            </DropdownMenuRadioGroup>
+          </DropdownMenuGroup>
+          <DropdownMenuSeparator />
+          <DropdownMenuCheckboxItem checked={showImageInfo} onCheckedChange={(checked) => onShowImageInfoChange(Boolean(checked))}>
+            <Info />显示图片信息
+          </DropdownMenuCheckboxItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
 
       {selectedCount > 0 && (
         <>
@@ -129,5 +193,14 @@ export function CanvasToolbar({
         </>
       )}
     </div>
+  );
+}
+
+function ArrangeItem({ label, icon, disabled, onClick }: { label: string; icon: React.ReactNode; disabled?: boolean; onClick: () => void }) {
+  return (
+    <DropdownMenuItem disabled={disabled} onClick={onClick}>
+      {icon}
+      {label}
+    </DropdownMenuItem>
   );
 }

--- a/frontend/src/components/canvas/components/canvas-zoom-controls.tsx
+++ b/frontend/src/components/canvas/components/canvas-zoom-controls.tsx
@@ -64,7 +64,13 @@ export function CanvasZoomControls({ scale, onScaleChange, onReset, isMiniMapOpe
             <Shortcut label="Ctrl / Cmd + 拖动" value="框选多个节点" />
             <Shortcut label="Shift / Ctrl / Cmd + 点击" value="追加选择节点" />
             <Shortcut label="Ctrl / Cmd + C / V" value="复制 / 粘贴节点" />
+            <Shortcut label="Ctrl / Cmd + Z" value="撤销" />
+            <Shortcut label="Ctrl / Cmd + Shift + Z" value="重做" />
+            <Shortcut label="Ctrl / Cmd + F" value="搜索并定位节点" />
             <Shortcut label="Delete / Backspace" value="删除选中" />
+            <Shortcut label="双击节点标题" value="原位编辑标题" />
+            <Shortcut label="Enter / 失焦" value="保存标题" />
+            <Shortcut label="Escape" value="取消标题修改" />
           </div>
         </DialogContent>
       </Dialog>

--- a/frontend/src/components/canvas/components/canvas-zoom-controls.tsx
+++ b/frontend/src/components/canvas/components/canvas-zoom-controls.tsx
@@ -59,9 +59,11 @@ export function CanvasZoomControls({ scale, onScaleChange, onReset, isMiniMapOpe
             <DialogTitle>快捷键</DialogTitle>
           </DialogHeader>
           <div className={cn("space-y-3 border-t border-border pt-4 text-sm")}>
-            <Shortcut label="拖动画布" value="平移视图" />
+            <Shortcut label="选择模式 + 空白拖动" value="框选节点" />
+            <Shortcut label="抓手模式 + 空白拖动" value="平移视图" />
+            <Shortcut label="空格 + 拖动" value="临时平移视图" />
+            <Shortcut label="鼠标中键拖动" value="平移视图" />
             <Shortcut label="滚轮" value="缩放画布" />
-            <Shortcut label="Ctrl / Cmd + 拖动" value="框选多个节点" />
             <Shortcut label="Shift / Ctrl / Cmd + 点击" value="追加选择节点" />
             <Shortcut label="Ctrl / Cmd + C / V" value="复制 / 粘贴节点" />
             <Shortcut label="Ctrl / Cmd + Z" value="撤销" />

--- a/frontend/src/components/canvas/components/infinite-canvas.tsx
+++ b/frontend/src/components/canvas/components/infinite-canvas.tsx
@@ -3,11 +3,12 @@
 import React, { useEffect, useRef, useState } from "react";
 
 import { canvasTheme, type CanvasBackgroundMode } from "../lib/canvas-theme";
-import type { ViewportTransform } from "../types";
+import type { CanvasInteractionMode, ViewportTransform } from "../types";
 
 type InfiniteCanvasProps = {
   containerRef: React.RefObject<HTMLDivElement | null>;
   viewport: ViewportTransform;
+  interactionMode: CanvasInteractionMode;
   backgroundMode?: CanvasBackgroundMode;
   onViewportChange: (viewport: ViewportTransform) => void;
   onCanvasMouseDown?: (event: React.PointerEvent<HTMLDivElement>) => void;
@@ -20,7 +21,7 @@ type InfiniteCanvasProps = {
 /** 浮层选择器：滚轮缩放时跳过弹窗/菜单/下拉，避免与其滚动冲突。 */
 const OVERLAY_SELECTOR = '[data-canvas-no-zoom],[role="dialog"],[role="menu"],[role="listbox"],[data-radix-popper-content-wrapper]';
 
-export function InfiniteCanvas({ containerRef, viewport, backgroundMode = "lines", onViewportChange, onCanvasMouseDown, onCanvasDeselect, onContextMenu, onDrop, children }: InfiniteCanvasProps) {
+export function InfiniteCanvas({ containerRef, viewport, interactionMode, backgroundMode = "lines", onViewportChange, onCanvasMouseDown, onCanvasDeselect, onContextMenu, onDrop, children }: InfiniteCanvasProps) {
   const theme = canvasTheme;
   const panState = useRef({
     isPanning: false,
@@ -93,14 +94,20 @@ export function InfiniteCanvas({ containerRef, viewport, backgroundMode = "lines
     if (target?.closest("[data-connection-create-menu]")) return;
     const isBackgroundClick = !target?.closest("[data-node-id],[data-connection-id]");
 
-    if (event.button === 0 && (event.ctrlKey || event.metaKey) && isBackgroundClick) {
+    const shouldPan = interactionMode === "pan" || isSpacePressed;
+
+    if (isBackgroundClick && (event.button === 0 || event.button === 1) && document.activeElement instanceof HTMLElement) {
+      document.activeElement.blur();
+    }
+
+    if (event.button === 0 && !shouldPan && isBackgroundClick) {
       event.preventDefault();
       event.currentTarget.setPointerCapture(event.pointerId);
       onCanvasMouseDown?.(event);
       return;
     }
 
-    if (event.button === 1 || (event.button === 0 && !isSpacePressed && isBackgroundClick)) {
+    if (event.button === 1 || (event.button === 0 && shouldPan && isBackgroundClick)) {
       event.preventDefault();
       event.currentTarget.setPointerCapture(event.pointerId);
       panState.current = {
@@ -115,9 +122,6 @@ export function InfiniteCanvas({ containerRef, viewport, backgroundMode = "lines
       return;
     }
 
-    if (event.button === 0 && isSpacePressed && isBackgroundClick) {
-      event.preventDefault();
-    }
   };
 
   useEffect(() => {
@@ -177,7 +181,8 @@ export function InfiniteCanvas({ containerRef, viewport, backgroundMode = "lines
   return (
     <div
       ref={containerRef}
-      className="relative h-full w-full cursor-grab select-none overflow-hidden"
+      data-canvas-mode={interactionMode}
+      className={`relative h-full w-full select-none overflow-hidden ${interactionMode === "pan" || isSpacePressed ? "cursor-grab" : "cursor-crosshair"}`}
       style={{ background: theme.canvas.background }}
       onPointerDown={handlePointerDown}
       onWheel={handleWheel}

--- a/frontend/src/components/canvas/lib/__tests__/canvas-prompt-routes.test.ts
+++ b/frontend/src/components/canvas/lib/__tests__/canvas-prompt-routes.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+
+import { CanvasNodeType, type CanvasConnection, type CanvasNodeData } from "../../types";
+import {
+  enumeratePromptRoutes,
+  findSelectedPromptRoute,
+  isInvalidPromptRouteSelection,
+  MAX_PROMPT_ROUTES,
+  promptRouteId,
+} from "../canvas-prompt-routes";
+
+function textNode(id: string, title: string): CanvasNodeData {
+  return {
+    id,
+    title,
+    type: CanvasNodeType.Text,
+    position: { x: 0, y: 0 },
+    width: 240,
+    height: 160,
+    metadata: { content: title },
+  };
+}
+
+function configNode(id: string): CanvasNodeData {
+  return {
+    id,
+    title: id,
+    type: CanvasNodeType.Config,
+    position: { x: 0, y: 0 },
+    width: 320,
+    height: 240,
+  };
+}
+
+function connection(id: string, fromNodeId: string, toNodeId: string): CanvasConnection {
+  return { id, fromNodeId, toNodeId };
+}
+
+describe("canvas prompt routes", () => {
+  it("enumerates every ordered text path into a config", () => {
+    const nodes = [textNode("core", "核心提示词"), textNode("concept", "城市创意"), textNode("beijing", "北京专属"), configNode("config-1")];
+    const connections = [
+      connection("core-concept", "core", "concept"),
+      connection("concept-beijing", "concept", "beijing"),
+      connection("core-beijing", "core", "beijing"),
+      connection("beijing-config-1", "beijing", "config-1"),
+    ];
+
+    const result = enumeratePromptRoutes("config-1", nodes, connections);
+
+    expect(result.truncated).toBe(false);
+    expect(result.routes.map((route) => route.connectionIds)).toEqual([
+      ["core-concept", "concept-beijing", "beijing-config-1"],
+      ["core-beijing", "beijing-config-1"],
+    ]);
+    expect(result.routes.map((route) => route.label)).toEqual([
+      "核心提示词 -> 城市创意 -> 北京专属",
+      "核心提示词 -> 北京专属",
+    ]);
+  });
+
+  it("does not emit a route whose only upstream continuation is cyclic", () => {
+    const nodes = [textNode("a", "A"), textNode("b", "B"), configNode("config")];
+    const connections = [connection("a-b", "a", "b"), connection("b-a", "b", "a"), connection("b-config", "b", "config")];
+
+    expect(enumeratePromptRoutes("config", nodes, connections).routes).toEqual([]);
+  });
+
+  it("suffixes duplicate labels without changing route identity", () => {
+    const nodes = [textNode("a", "城市专属"), textNode("b", "城市专属"), configNode("config")];
+    const connections = [connection("a-config", "a", "config"), connection("b-config", "b", "config")];
+
+    const routes = enumeratePromptRoutes("config", nodes, connections).routes;
+
+    expect(routes.map((route) => route.label)).toEqual(["城市专属", "城市专属 (2)"]);
+    expect(routes.map((route) => route.id)).toEqual([promptRouteId(["a-config"]), promptRouteId(["b-config"])]);
+  });
+
+  it("caps dense graphs and reports truncation", () => {
+    const roots = Array.from({ length: MAX_PROMPT_ROUTES + 1 }, (_, index) => textNode(`root-${index}`, `路线 ${index}`));
+    const nodes = [...roots, configNode("config")];
+    const connections = roots.map((node, index) => connection(`route-${index}`, node.id, "config"));
+
+    const result = enumeratePromptRoutes("config", nodes, connections);
+
+    expect(result.routes).toHaveLength(MAX_PROMPT_ROUTES);
+    expect(result.truncated).toBe(true);
+  });
+
+  it("resolves valid selections and rejects stale ones", () => {
+    const nodes = [textNode("source", "来源"), configNode("config")];
+    const connections = [connection("source-config", "source", "config")];
+    const routes = enumeratePromptRoutes("config", nodes, connections).routes;
+
+    expect(findSelectedPromptRoute({ mode: "route", connectionIds: ["source-config"] }, routes)?.id).toBe(promptRouteId(["source-config"]));
+    expect(isInvalidPromptRouteSelection({ mode: "route", connectionIds: ["missing"] }, routes)).toBe(true);
+    expect(isInvalidPromptRouteSelection({ mode: "manual" }, routes)).toBe(false);
+    expect(isInvalidPromptRouteSelection(undefined, routes)).toBe(false);
+  });
+});

--- a/frontend/src/components/canvas/lib/canvas-prompt-routes.ts
+++ b/frontend/src/components/canvas/lib/canvas-prompt-routes.ts
@@ -1,0 +1,121 @@
+import {
+  CanvasNodeType,
+  type CanvasConnection,
+  type CanvasNodeData,
+  type CanvasPromptRouteSelection,
+} from "../types";
+
+export const MANUAL_PROMPT_ROUTE_VALUE = "manual";
+export const MAX_PROMPT_ROUTES = 100;
+
+export type CanvasPromptRoute = {
+  id: string;
+  label: string;
+  nodeIds: string[];
+  connectionIds: string[];
+};
+
+export type PromptRouteEnumeration = {
+  routes: CanvasPromptRoute[];
+  truncated: boolean;
+};
+
+export function promptRouteId(connectionIds: string[]) {
+  return `route:${connectionIds.join("|")}`;
+}
+
+export function enumeratePromptRoutes(
+  configNodeId: string,
+  nodes: CanvasNodeData[],
+  connections: CanvasConnection[],
+  limit = MAX_PROMPT_ROUTES,
+): PromptRouteEnumeration {
+  const nodeById = new Map(nodes.map((node) => [node.id, node]));
+  if (nodeById.get(configNodeId)?.type !== CanvasNodeType.Config || limit <= 0) {
+    return { routes: [], truncated: false };
+  }
+
+  const incoming = new Map<string, CanvasConnection[]>();
+  for (const connection of connections) {
+    const from = nodeById.get(connection.fromNodeId);
+    const to = nodeById.get(connection.toNodeId);
+    const eligible = from?.type === CanvasNodeType.Text &&
+      (to?.type === CanvasNodeType.Text || to?.type === CanvasNodeType.Config);
+    if (!eligible) continue;
+    incoming.set(connection.toNodeId, [...(incoming.get(connection.toNodeId) ?? []), connection]);
+  }
+
+  const rawRoutes: Omit<CanvasPromptRoute, "label">[] = [];
+  let truncated = false;
+
+  const walkTextNode = (
+    nodeId: string,
+    reverseNodeIds: string[],
+    reverseConnectionIds: string[],
+    visited: Set<string>,
+  ) => {
+    if (truncated) return;
+    const incomingConnections = incoming.get(nodeId) ?? [];
+    if (incomingConnections.length === 0) {
+      if (rawRoutes.length >= limit) {
+        truncated = true;
+        return;
+      }
+      const nodeIds = [...reverseNodeIds].reverse();
+      const connectionIds = [...reverseConnectionIds].reverse();
+      rawRoutes.push({ id: promptRouteId(connectionIds), nodeIds, connectionIds });
+      return;
+    }
+
+    for (const connection of incomingConnections) {
+      if (visited.has(connection.fromNodeId)) continue;
+      const nextVisited = new Set(visited);
+      nextVisited.add(connection.fromNodeId);
+      walkTextNode(
+        connection.fromNodeId,
+        [...reverseNodeIds, connection.fromNodeId],
+        [...reverseConnectionIds, connection.id],
+        nextVisited,
+      );
+      if (truncated) return;
+    }
+  };
+
+  for (const connection of incoming.get(configNodeId) ?? []) {
+    walkTextNode(
+      connection.fromNodeId,
+      [connection.fromNodeId],
+      [connection.id],
+      new Set([configNodeId, connection.fromNodeId]),
+    );
+    if (truncated) break;
+  }
+
+  const labelCounts = new Map<string, number>();
+  const routes = rawRoutes.map((route) => {
+    const baseLabel = route.nodeIds
+      .map((nodeId) => nodeById.get(nodeId)?.title.trim() || nodeId)
+      .join(" -> ");
+    const occurrence = (labelCounts.get(baseLabel) ?? 0) + 1;
+    labelCounts.set(baseLabel, occurrence);
+    return { ...route, label: occurrence === 1 ? baseLabel : `${baseLabel} (${occurrence})` };
+  });
+
+  return { routes, truncated };
+}
+
+export function findSelectedPromptRoute(
+  selection: CanvasPromptRouteSelection | undefined,
+  routes: CanvasPromptRoute[],
+) {
+  if (selection?.mode !== "route") return null;
+  const id = promptRouteId(selection.connectionIds);
+  return routes.find((route) => route.id === id) ?? null;
+}
+
+export function isInvalidPromptRouteSelection(
+  selection: CanvasPromptRouteSelection | undefined,
+  routes: CanvasPromptRoute[],
+) {
+  return selection?.mode === "route" && !findSelectedPromptRoute(selection, routes);
+}

--- a/frontend/src/components/canvas/stores/__tests__/use-canvas-store.test.ts
+++ b/frontend/src/components/canvas/stores/__tests__/use-canvas-store.test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const setItemMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+
+vi.mock("../../lib/localforage-storage", () => ({
+  localForageStorage: {
+    getItem: vi.fn().mockResolvedValue(null),
+    setItem: setItemMock,
+    removeItem: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+import { flushPendingCanvasSave, useCanvasStore, type CanvasProject } from "../use-canvas-store";
+import { CanvasNodeType } from "../../types";
+
+const project: CanvasProject = {
+  id: "project",
+  title: "Canvas",
+  createdAt: "2026-07-27T00:00:00.000Z",
+  updatedAt: "2026-07-27T00:00:00.000Z",
+  nodes: [],
+  connections: [],
+  backgroundMode: "lines",
+  showImageInfo: false,
+  viewport: { x: 0, y: 0, k: 1 },
+};
+
+describe("canvas store persistence semantics", () => {
+  beforeEach(() => {
+    setItemMock.mockClear();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-28T08:00:00.000Z"));
+    useCanvasStore.setState({ hydrated: true, projects: [structuredClone(project)] });
+    useCanvasStore.setState({ saveStatus: "saved" });
+  });
+
+  it("does not touch updatedAt for viewport-only changes", () => {
+    useCanvasStore.getState().updateProject("project", { viewport: { x: 20, y: 30, k: 1.2 } }, { touchUpdatedAt: false });
+
+    expect(useCanvasStore.getState().openProject("project")?.updatedAt).toBe(project.updatedAt);
+  });
+
+  it("touches updatedAt for content changes", () => {
+    useCanvasStore.getState().updateProject("project", { nodes: [{ id: "n", title: "N", type: CanvasNodeType.Text, position: { x: 0, y: 0 }, width: 100, height: 80 }] });
+
+    expect(useCanvasStore.getState().openProject("project")?.updatedAt).toBe("2026-07-28T08:00:00.000Z");
+  });
+
+  it("flushes a queued save before leaving the canvas", async () => {
+    useCanvasStore.getState().renameProject("project", "Renamed");
+
+    expect(useCanvasStore.getState().saveStatus).toBe("saving");
+    await flushPendingCanvasSave();
+
+    expect(setItemMock).toHaveBeenCalled();
+    expect(useCanvasStore.getState().saveStatus).toBe("saved");
+  });
+});

--- a/frontend/src/components/canvas/stores/use-canvas-store.ts
+++ b/frontend/src/components/canvas/stores/use-canvas-store.ts
@@ -19,9 +19,12 @@ export type CanvasProject = {
 };
 
 type CanvasProjectPatch = Partial<Pick<CanvasProject, "nodes" | "connections" | "backgroundMode" | "showImageInfo" | "viewport">>;
+type CanvasProjectUpdateOptions = { touchUpdatedAt?: boolean };
+export type CanvasSaveStatus = "saved" | "saving" | "error";
 
 type CanvasStore = {
   hydrated: boolean;
+  saveStatus: CanvasSaveStatus;
   projects: CanvasProject[];
   createProject: (title?: string) => string;
   importProject: (project: Partial<CanvasProject>) => string;
@@ -29,7 +32,7 @@ type CanvasStore = {
   renameProject: (id: string, title: string) => void;
   deleteProjects: (ids: string[]) => void;
   replaceProjects: (projects: CanvasProject[]) => void;
-  updateProject: (id: string, patch: CanvasProjectPatch) => void;
+  updateProject: (id: string, patch: CanvasProjectPatch, options?: CanvasProjectUpdateOptions) => void;
 };
 
 const initialViewport: ViewportTransform = { x: 0, y: 0, k: 1 };
@@ -37,6 +40,27 @@ const CANVAS_STORE_KEY = "nova-image:canvas_store";
 type PersistedCanvasState = Pick<CanvasStore, "projects">;
 let saveTimer: ReturnType<typeof setTimeout> | null = null;
 let queuedPersistState: PersistedCanvasState | null = null;
+let queuedPersistValue: { name: string; value: StorageValue<CanvasStore> } | null = null;
+
+async function persistQueuedCanvasState() {
+  const queued = queuedPersistValue;
+  if (!queued) return;
+  queuedPersistValue = null;
+  try {
+    await localForageStorage.setItem(queued.name, JSON.stringify(queued.value));
+    if (!queuedPersistValue) useCanvasStore.setState({ saveStatus: "saved" });
+  } catch {
+    useCanvasStore.setState({ saveStatus: "error" });
+  }
+}
+
+export async function flushPendingCanvasSave() {
+  if (saveTimer) {
+    clearTimeout(saveTimer);
+    saveTimer = null;
+  }
+  await persistQueuedCanvasState();
+}
 
 const canvasStorage: PersistStorage<CanvasStore> = {
   getItem: async (name) => {
@@ -50,10 +74,12 @@ const canvasStorage: PersistStorage<CanvasStore> = {
     const nextState = value.state as PersistedCanvasState;
     if (queuedPersistState && queuedPersistState.projects === nextState.projects) return;
     queuedPersistState = nextState;
+    queuedPersistValue = { name, value };
+    useCanvasStore.setState({ saveStatus: "saving" });
     if (saveTimer) clearTimeout(saveTimer);
     saveTimer = setTimeout(() => {
       saveTimer = null;
-      void localForageStorage.setItem(name, JSON.stringify(value));
+      void persistQueuedCanvasState();
     }, 400);
   },
   removeItem: (name) => localForageStorage.removeItem(name),
@@ -63,6 +89,7 @@ export const useCanvasStore = create<CanvasStore>()(
   persist(
     (set, get) => ({
       hydrated: false,
+      saveStatus: "saved",
       projects: [],
       createProject: (title = "未命名画布") => {
         const now = new Date().toISOString();
@@ -110,9 +137,18 @@ export const useCanvasStore = create<CanvasStore>()(
           return { projects };
         }),
       replaceProjects: (projects) => set({ projects }),
-      updateProject: (id, patch) =>
+      updateProject: (id, patch, options) =>
         set((state) => ({
-          projects: state.projects.map((project) => (project.id === id ? { ...project, ...patch, updatedAt: new Date().toISOString() } : project)),
+          projects: state.projects.map((project) => {
+            if (project.id !== id) return project;
+            const changed = Object.entries(patch).some(([key, value]) => project[key as keyof CanvasProject] !== value);
+            if (!changed) return project;
+            return {
+              ...project,
+              ...patch,
+              updatedAt: options?.touchUpdatedAt === false ? project.updatedAt : new Date().toISOString(),
+            };
+          }),
         })),
     }),
     {

--- a/frontend/src/components/canvas/types.ts
+++ b/frontend/src/components/canvas/types.ts
@@ -20,6 +20,7 @@ export enum CanvasNodeType {
 }
 
 export type CanvasNodeStatus = "idle" | "success" | "loading" | "submitting" | "queued" | "processing" | "error";
+export type CanvasInteractionMode = "select" | "pan";
 /** 移植后画布只生成图像（走宿主任务队列），不含 video/audio。 */
 export type CanvasGenerationMode = "image";
 export type CanvasImageGenerationType = "generation" | "edit";

--- a/frontend/src/components/canvas/types.ts
+++ b/frontend/src/components/canvas/types.ts
@@ -37,6 +37,10 @@ export type CanvasGenerationConfig = {
   gptImageBackground: GptImageBackground;
 };
 
+export type CanvasPromptRouteSelection =
+  | { mode: "manual" }
+  | { mode: "route"; connectionIds: string[] };
+
 export type CanvasNodeMetadata = {
   content?: string;
   composerContent?: string;
@@ -67,6 +71,8 @@ export type CanvasNodeMetadata = {
   genConfig?: CanvasGenerationConfig;
   /** 配置节点：锁定结果节点模式 */
   lockResultNodes?: boolean;
+  /** 配置节点：手动编排或绑定的上游提示词路线 */
+  promptRouteSelection?: CanvasPromptRouteSelection;
   /** 单节点生成任务 ID（用于轮询 + 刷新恢复） */
   generationTaskId?: string;
   /** 单节点生成开始时间戳（用于计算用时） */

--- a/frontend/src/components/canvas/types.ts
+++ b/frontend/src/components/canvas/types.ts
@@ -125,6 +125,12 @@ export type SelectionBox = {
 
 export type ContextMenuState =
   | {
+      type: "canvas";
+      x: number;
+      y: number;
+      position: Position;
+    }
+  | {
       type: "node";
       x: number;
       y: number;

--- a/frontend/src/components/canvas/utils/__tests__/canvas-clipboard.test.ts
+++ b/frontend/src/components/canvas/utils/__tests__/canvas-clipboard.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+
+import { CanvasNodeType, type CanvasConnection, type CanvasNodeData } from "../../types";
+import { duplicateCanvasSelection } from "../canvas-clipboard";
+
+const nodes: CanvasNodeData[] = [
+  { id: "a", type: CanvasNodeType.Text, title: "A", position: { x: 10, y: 20 }, width: 100, height: 80, metadata: { content: "A" } },
+  { id: "b", type: CanvasNodeType.Config, title: "B", position: { x: 200, y: 20 }, width: 180, height: 120, metadata: { composerContent: "B" } },
+  { id: "outside", type: CanvasNodeType.Text, title: "Outside", position: { x: 500, y: 20 }, width: 100, height: 80, metadata: {} },
+];
+const connections: CanvasConnection[] = [
+  { id: "a-b", fromNodeId: "a", toNodeId: "b" },
+  { id: "b-outside", fromNodeId: "b", toNodeId: "outside" },
+];
+
+describe("canvas clipboard", () => {
+  it("duplicates selected nodes and only the connections internal to that selection", () => {
+    const ids = ["clone-a", "clone-b", "clone-connection"];
+
+    const result = duplicateCanvasSelection(nodes, connections, ["a", "b"], () => ids.shift()!, 40);
+
+    expect(result.nodes.map((node) => node.id)).toEqual(["clone-a", "clone-b"]);
+    expect(result.nodes.map((node) => node.position)).toEqual([{ x: 50, y: 60 }, { x: 240, y: 60 }]);
+    expect(result.connections).toEqual([
+      { id: "clone-connection", fromNodeId: "clone-a", toNodeId: "clone-b" },
+    ]);
+  });
+});

--- a/frontend/src/components/canvas/utils/__tests__/canvas-layout.test.ts
+++ b/frontend/src/components/canvas/utils/__tests__/canvas-layout.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+
+import { CanvasNodeType, type CanvasConnection, type CanvasNodeData } from "../../types";
+import { arrangeCanvasNodes, layoutCanvasGraph } from "../canvas-layout";
+
+function node(id: string, x: number, y: number, width = 100, height = 80): CanvasNodeData {
+  return { id, type: CanvasNodeType.Text, title: id, position: { x, y }, width, height, metadata: {} };
+}
+
+describe("canvas layout", () => {
+  it("aligns selected nodes to the first selected node without moving other nodes", () => {
+    const nodes = [node("anchor", 120, 40), node("second", 360, 180), node("other", 700, 240)];
+
+    const result = arrangeCanvasNodes(nodes, ["anchor", "second"], "align-left");
+
+    expect(result.find((item) => item.id === "anchor")?.position.x).toBe(120);
+    expect(result.find((item) => item.id === "second")?.position.x).toBe(120);
+    expect(result.find((item) => item.id === "other")?.position).toEqual({ x: 700, y: 240 });
+  });
+
+  it("distributes three nodes with equal horizontal gaps while keeping the outer nodes fixed", () => {
+    const nodes = [node("left", 0, 0, 100), node("middle", 170, 80, 80), node("right", 400, 20, 100)];
+
+    const result = arrangeCanvasNodes(nodes, ["left", "middle", "right"], "distribute-horizontal");
+
+    const left = result.find((item) => item.id === "left")!;
+    const middle = result.find((item) => item.id === "middle")!;
+    const right = result.find((item) => item.id === "right")!;
+    expect(left.position.x).toBe(0);
+    expect(right.position.x).toBe(400);
+    expect(middle.position.x - (left.position.x + left.width)).toBe(110);
+    expect(right.position.x - (middle.position.x + middle.width)).toBe(110);
+  });
+
+  it("lays out a connected generation chain from left to right without moving isolated nodes", () => {
+    const nodes = [
+      node("core", 200, 200),
+      node("city", 20, 500),
+      { ...node("config", 80, 40, 180, 140), type: CanvasNodeType.Config },
+      { ...node("result", 500, 400, 160, 160), type: CanvasNodeType.Image },
+      node("isolated", 900, 900),
+    ];
+    const connections: CanvasConnection[] = [
+      { id: "core-city", fromNodeId: "core", toNodeId: "city" },
+      { id: "city-config", fromNodeId: "city", toNodeId: "config" },
+      { id: "config-result", fromNodeId: "config", toNodeId: "result" },
+    ];
+
+    const result = layoutCanvasGraph(nodes, connections, ["core", "city", "config", "result"]);
+    const x = (id: string) => result.find((item) => item.id === id)!.position.x;
+
+    expect(x("core")).toBeLessThan(x("city"));
+    expect(x("city")).toBeLessThan(x("config"));
+    expect(x("config")).toBeLessThan(x("result"));
+    expect(result.find((item) => item.id === "isolated")?.position).toEqual({ x: 900, y: 900 });
+  });
+});

--- a/frontend/src/components/canvas/utils/__tests__/canvas-resource-references.test.ts
+++ b/frontend/src/components/canvas/utils/__tests__/canvas-resource-references.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+
+import { CanvasNodeType, type CanvasConnection, type CanvasNodeData } from "../../types";
+import { getGenerationResourceNodes } from "../canvas-resource-references";
+
+function node(id: string, type: CanvasNodeType, metadata: CanvasNodeData["metadata"] = {}): CanvasNodeData {
+  return { id, type, title: id, metadata, position: { x: 0, y: 0 }, width: 240, height: 160 };
+}
+
+function edge(id: string, fromNodeId: string, toNodeId: string): CanvasConnection {
+  return { id, fromNodeId, toNodeId };
+}
+
+describe("getGenerationResourceNodes", () => {
+  it("walks upstream resources and stops at the previous config boundary", () => {
+    const nodes = [
+      node("original", CanvasNodeType.Image, { content: "data:image/png;base64,original" }),
+      node("previous-config", CanvasNodeType.Config),
+      node("generated", CanvasNodeType.Image, { content: "data:image/png;base64,generated" }),
+      node("instruction", CanvasNodeType.Text, { content: "修改天空" }),
+      node("current-config", CanvasNodeType.Config),
+    ];
+    const connections = [
+      edge("original-previous", "original", "previous-config"),
+      edge("previous-generated", "previous-config", "generated"),
+      edge("generated-instruction", "generated", "instruction"),
+      edge("instruction-current", "instruction", "current-config"),
+    ];
+
+    expect(getGenerationResourceNodes("current-config", nodes, connections).map((item) => item.id)).toEqual([
+      "generated",
+      "instruction",
+    ]);
+  });
+});

--- a/frontend/src/components/canvas/utils/canvas-clipboard.ts
+++ b/frontend/src/components/canvas/utils/canvas-clipboard.ts
@@ -1,0 +1,43 @@
+import type { CanvasConnection, CanvasNodeData } from "../types";
+
+export function duplicateCanvasSelection(
+  nodes: CanvasNodeData[],
+  connections: CanvasConnection[],
+  selectedIds: string[],
+  createId: () => string,
+  offset = 40,
+) {
+  const selectedSet = new Set(selectedIds);
+  const idMap = new Map<string, string>();
+  const clonedNodes = nodes.filter((node) => selectedSet.has(node.id)).map((node) => {
+    const id = createId();
+    idMap.set(node.id, id);
+    return {
+      ...node,
+      id,
+      position: { x: node.position.x + offset, y: node.position.y + offset },
+      metadata: cloneMetadata(node.metadata),
+    };
+  });
+  const clonedConnections = connections
+    .filter((connection) => selectedSet.has(connection.fromNodeId) && selectedSet.has(connection.toNodeId))
+    .map((connection) => ({
+      id: createId(),
+      fromNodeId: idMap.get(connection.fromNodeId)!,
+      toNodeId: idMap.get(connection.toNodeId)!,
+    }));
+  return { nodes: clonedNodes, connections: clonedConnections };
+}
+
+function cloneMetadata(metadata: CanvasNodeData["metadata"]): CanvasNodeData["metadata"] {
+  if (!metadata) return undefined;
+  return {
+    ...metadata,
+    genConfig: metadata.genConfig ? { ...metadata.genConfig } : undefined,
+    promptRouteSelection: metadata.promptRouteSelection?.mode === "route"
+      ? { mode: "route", connectionIds: [...metadata.promptRouteSelection.connectionIds] }
+      : metadata.promptRouteSelection,
+    references: metadata.references ? [...metadata.references] : undefined,
+    batchChildIds: metadata.batchChildIds ? [...metadata.batchChildIds] : undefined,
+  };
+}

--- a/frontend/src/components/canvas/utils/canvas-layout.ts
+++ b/frontend/src/components/canvas/utils/canvas-layout.ts
@@ -1,0 +1,119 @@
+import dagre from "@dagrejs/dagre";
+
+import type { CanvasConnection, CanvasNodeData } from "../types";
+
+export type CanvasArrangeMode =
+  | "align-left"
+  | "align-center-horizontal"
+  | "align-right"
+  | "align-top"
+  | "align-center-vertical"
+  | "align-bottom"
+  | "distribute-horizontal"
+  | "distribute-vertical"
+  | "row"
+  | "column"
+  | "grid";
+
+const ARRANGE_GAP = 32;
+
+export function arrangeCanvasNodes(nodes: CanvasNodeData[], selectedIds: string[], mode: CanvasArrangeMode) {
+  const selectedSet = new Set(selectedIds);
+  const selected = selectedIds.map((id) => nodes.find((node) => node.id === id)).filter((node): node is CanvasNodeData => Boolean(node));
+  if (selected.length < 2) return nodes;
+
+  const positions = new Map(selected.map((node) => [node.id, { ...node.position }]));
+  const anchor = selected[0];
+
+  if (mode === "align-left") selected.forEach((node) => positions.set(node.id, { ...node.position, x: anchor.position.x }));
+  if (mode === "align-center-horizontal") {
+    const center = anchor.position.x + anchor.width / 2;
+    selected.forEach((node) => positions.set(node.id, { ...node.position, x: center - node.width / 2 }));
+  }
+  if (mode === "align-right") {
+    const right = anchor.position.x + anchor.width;
+    selected.forEach((node) => positions.set(node.id, { ...node.position, x: right - node.width }));
+  }
+  if (mode === "align-top") selected.forEach((node) => positions.set(node.id, { ...node.position, y: anchor.position.y }));
+  if (mode === "align-center-vertical") {
+    const center = anchor.position.y + anchor.height / 2;
+    selected.forEach((node) => positions.set(node.id, { ...node.position, y: center - node.height / 2 }));
+  }
+  if (mode === "align-bottom") {
+    const bottom = anchor.position.y + anchor.height;
+    selected.forEach((node) => positions.set(node.id, { ...node.position, y: bottom - node.height }));
+  }
+  if (mode === "distribute-horizontal" && selected.length >= 3) distribute(selected, positions, "horizontal");
+  if (mode === "distribute-vertical" && selected.length >= 3) distribute(selected, positions, "vertical");
+  if (mode === "row") placeSequence(selected, positions, "horizontal");
+  if (mode === "column") placeSequence(selected, positions, "vertical");
+  if (mode === "grid") placeGrid(selected, positions);
+
+  return nodes.map((node) => selectedSet.has(node.id) ? { ...node, position: positions.get(node.id) ?? node.position } : node);
+}
+
+export function layoutCanvasGraph(nodes: CanvasNodeData[], connections: CanvasConnection[], targetIds: string[]) {
+  const targetSet = new Set(targetIds);
+  const targets = nodes.filter((node) => targetSet.has(node.id));
+  if (targets.length < 2) return nodes;
+
+  const graph = new dagre.graphlib.Graph();
+  graph.setGraph({ rankdir: "LR", ranksep: 96, nodesep: 48, marginx: 0, marginy: 0 });
+  graph.setDefaultEdgeLabel(() => ({}));
+  targets.forEach((node) => graph.setNode(node.id, { width: node.width, height: node.height }));
+  connections.forEach((connection) => {
+    if (targetSet.has(connection.fromNodeId) && targetSet.has(connection.toNodeId)) {
+      graph.setEdge(connection.fromNodeId, connection.toNodeId);
+    }
+  });
+  dagre.layout(graph);
+
+  const raw = targets.map((node) => {
+    const position = graph.node(node.id) as { x: number; y: number };
+    return { node, x: position.x - node.width / 2, y: position.y - node.height / 2 };
+  });
+  const originalMinX = Math.min(...targets.map((node) => node.position.x));
+  const originalMinY = Math.min(...targets.map((node) => node.position.y));
+  const rawMinX = Math.min(...raw.map((item) => item.x));
+  const rawMinY = Math.min(...raw.map((item) => item.y));
+  const positions = new Map(raw.map(({ node, x, y }) => [node.id, { x: x - rawMinX + originalMinX, y: y - rawMinY + originalMinY }]));
+
+  return nodes.map((node) => targetSet.has(node.id) ? { ...node, position: positions.get(node.id) ?? node.position } : node);
+}
+
+function distribute(nodes: CanvasNodeData[], positions: Map<string, CanvasNodeData["position"]>, axis: "horizontal" | "vertical") {
+  const sorted = [...nodes].sort((a, b) => axis === "horizontal" ? a.position.x - b.position.x : a.position.y - b.position.y);
+  const start = axis === "horizontal" ? sorted[0].position.x : sorted[0].position.y;
+  const last = sorted[sorted.length - 1];
+  const end = axis === "horizontal" ? last.position.x + last.width : last.position.y + last.height;
+  const totalSize = sorted.reduce((sum, node) => sum + (axis === "horizontal" ? node.width : node.height), 0);
+  const gap = (end - start - totalSize) / (sorted.length - 1);
+  let cursor = start;
+  sorted.forEach((node) => {
+    positions.set(node.id, axis === "horizontal" ? { ...node.position, x: cursor } : { ...node.position, y: cursor });
+    cursor += (axis === "horizontal" ? node.width : node.height) + gap;
+  });
+}
+
+function placeSequence(nodes: CanvasNodeData[], positions: Map<string, CanvasNodeData["position"]>, axis: "horizontal" | "vertical") {
+  let cursor = axis === "horizontal" ? nodes[0].position.x : nodes[0].position.y;
+  nodes.forEach((node) => {
+    positions.set(node.id, axis === "horizontal" ? { x: cursor, y: nodes[0].position.y } : { x: nodes[0].position.x, y: cursor });
+    cursor += (axis === "horizontal" ? node.width : node.height) + ARRANGE_GAP;
+  });
+}
+
+function placeGrid(nodes: CanvasNodeData[], positions: Map<string, CanvasNodeData["position"]>) {
+  const columns = Math.ceil(Math.sqrt(nodes.length));
+  const columnWidths = Array.from({ length: columns }, (_, column) => Math.max(...nodes.filter((_, index) => index % columns === column).map((node) => node.width)));
+  const rows = Math.ceil(nodes.length / columns);
+  const rowHeights = Array.from({ length: rows }, (_, row) => Math.max(...nodes.slice(row * columns, (row + 1) * columns).map((node) => node.height)));
+  const start = nodes[0].position;
+  nodes.forEach((node, index) => {
+    const column = index % columns;
+    const row = Math.floor(index / columns);
+    const x = start.x + columnWidths.slice(0, column).reduce((sum, width) => sum + width + ARRANGE_GAP, 0);
+    const y = start.y + rowHeights.slice(0, row).reduce((sum, height) => sum + height + ARRANGE_GAP, 0);
+    positions.set(node.id, { x, y });
+  });
+}

--- a/frontend/src/components/canvas/utils/canvas-resource-references.ts
+++ b/frontend/src/components/canvas/utils/canvas-resource-references.ts
@@ -43,10 +43,27 @@ export function getGenerationResourceNodes(nodeId: string, nodes: CanvasNodeData
 }
 
 function getContextResourceNodes(nodeId: string, nodes: CanvasNodeData[], connections: CanvasConnection[]) {
-  return connections
-    .filter((connection) => connection.toNodeId === nodeId)
-    .map((connection) => nodes.find((node) => node.id === connection.fromNodeId))
-    .filter((node): node is CanvasNodeData => Boolean(node && isResourceNode(node)));
+  const nodeById = new Map(nodes.map((node) => [node.id, node]));
+  const incoming = new Map<string, CanvasConnection[]>();
+  for (const connection of connections) {
+    incoming.set(connection.toNodeId, [...(incoming.get(connection.toNodeId) ?? []), connection]);
+  }
+
+  const result: CanvasNodeData[] = [];
+  const visited = new Set([nodeId]);
+  const walk = (targetId: string) => {
+    for (const connection of incoming.get(targetId) ?? []) {
+      if (visited.has(connection.fromNodeId)) continue;
+      visited.add(connection.fromNodeId);
+      const source = nodeById.get(connection.fromNodeId);
+      if (!source || source.type === CanvasNodeType.Config) continue;
+      walk(source.id);
+      if (isResourceNode(source)) result.push(source);
+    }
+  };
+
+  walk(nodeId);
+  return result;
 }
 
 function getConnectedConfigResourceNodes(nodeId: string, nodes: CanvasNodeData[], connections: CanvasConnection[]) {

--- a/frontend/src/components/ui/select.tsx
+++ b/frontend/src/components/ui/select.tsx
@@ -23,6 +23,7 @@ function Select<T extends string>({
   className,
   contentClassName,
   disabled,
+  ariaLabel,
   size = "default",
 }: {
   value: T
@@ -32,6 +33,7 @@ function Select<T extends string>({
   className?: string
   contentClassName?: string
   disabled?: boolean
+  ariaLabel?: string
   size?: "sm" | "default"
 }) {
   return (
@@ -43,6 +45,7 @@ function Select<T extends string>({
     >
       <SelectPrimitive.Trigger
         data-slot="select-trigger"
+        aria-label={ariaLabel}
         className={cn(
           "inline-flex w-full items-center justify-between gap-2 rounded-lg border border-input bg-transparent px-2.5 text-sm transition-colors outline-none select-none hover:bg-muted/50 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 data-[popup-open]:bg-muted/50 dark:bg-input/30",
           size === "sm" ? "h-7" : "h-8",

--- a/frontend/src/lib/__tests__/server-gpt-image-params.test.ts
+++ b/frontend/src/lib/__tests__/server-gpt-image-params.test.ts
@@ -42,6 +42,7 @@ describe('backend GPT Image advanced params forwarding', () => {
     expect(serverSource).toContain('function resolveGptImageRequestSize(request)');
     expect(serverSource).toContain('const customSize = normalizeCustomImageSize(request.customSize, 4096)');
     expect(serverSource).toContain('return getSupportedGptImageSize(request.model, request.outputSize, request.aspectRatio)');
-    expect(serverSource).toContain('return requestGptImage(apiKey, request, resolveGptImageRequestSize(request), { baseUrl });');
+    expect(serverSource).toContain('const resolvedSize = resolveGptImageRequestSize(request)');
+    expect(serverSource).toContain('return requestGptImage(apiKey, request, resolvedSize, { baseUrl });');
   });
 });

--- a/frontend/src/lib/__tests__/workspace-task-service.test.ts
+++ b/frontend/src/lib/__tests__/workspace-task-service.test.ts
@@ -1,7 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ackNovaTask, createNovaTask, resolveImageTaskProvider, type NovaTaskResponse } from '@/lib/ccode-task-client';
 import { downloadAndStoreImages } from '@/lib/image-downloader';
+import { syncDynamicModelExports } from '@/lib/gemini-config';
 import type { StoredJob } from '@/lib/job-store';
+import { saveRegistry } from '@/lib/nova-models';
 import {
   finalizeCompletedServerTask,
   submitTextToImage,
@@ -76,6 +78,31 @@ function createActions(initialJob: StoredJob): { actions: SubmitActions; getJob:
 }
 
 beforeEach(() => {
+  localStorage.clear();
+  saveRegistry({
+    imageModels: [{
+      id: 'gpt-image-2',
+      protocol: 'openai',
+      name: 'GPT Image 2',
+      modelId: 'gpt-image-2',
+      apiKey: 'test-api-key',
+      baseUrl: 'https://api.openai.com',
+      builtinPreset: 'gpt-image-2',
+      maxRefImages: 16,
+      maxOutputSize: '4K',
+      supportsAdvancedParams: true,
+    }],
+    textModels: [],
+    defaults: {
+      textToImage: 'gpt-image-2',
+      imageToImage: 'gpt-image-2',
+      reversePrompt: '',
+      agent: '',
+      promptOptimize: '',
+      imageDescribe: '',
+    },
+  });
+  syncDynamicModelExports();
   mockedAckNovaTask.mockReset();
   mockedAckNovaTask.mockResolvedValue(undefined);
   mockedCreateNovaTask.mockReset();
@@ -86,6 +113,7 @@ beforeEach(() => {
     apiKey: 'test-api-key',
     baseUrl: 'https://api.openai.com',
     protocol: 'openai',
+    modelId: 'gpt-image-2',
   });
 });
 


### PR DESCRIPTION
## Summary

- Enable streaming for OpenAI-compatible image generation requests.
- Support configurable `partial_images` requests.
- Automatically retry without streaming parameters when the upstream API does not support `stream` or `partial_images`.
- Add an integration test covering the streaming fallback flow.
- Allow infinite-canvas connections to be selected and deleted.
- Support deleting connections through the Delete/Backspace keys, toolbar, and context menu.
- Add regression tests for connection deletion.
- Ignore the local `docs/` workspace directory.

## Configuration

OpenAI image streaming can be controlled with:

- `NOVA_IMAGE_STREAM`: set to `false` to disable streaming.
- `NOVA_IMAGE_PARTIAL_IMAGES`: partial image count, limited to `0-3`.

## Testing

- `node --test backend/test/image-stream.integration.test.js`
- `cd frontend && npm test -- --run src/components/canvas/__tests__/CanvasEditor.connections.test.tsx`
- `cd frontend && npx eslint src/components/canvas/CanvasEditor.tsx src/components/canvas/__tests__/CanvasEditor.connections.test.tsx`