### PR TITLE
Fix canvas result image recovery

### DIFF
--- a/frontend/src/components/canvas/CanvasEditor.tsx
+++ b/frontend/src/components/canvas/CanvasEditor.tsx
@@ -68,6 +68,22 @@ type CanvasEditorProps = {
 };
 
 const MAX_HISTORY = 50;
+const RESULT_CACHE_RETRY_DELAYS = [15_000, 30_000, 60_000] as const;
+
+function waitForResultCacheRetry(ms: number, signal: AbortSignal) {
+  return new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      signal.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    const onAbort = () => {
+      clearTimeout(timer);
+      reject(new DOMException("Aborted", "AbortError"));
+    };
+    if (signal.aborted) onAbort();
+    else signal.addEventListener("abort", onAbort, { once: true });
+  });
+}
 
 function connectedNodeIds(seedId: string, connections: CanvasConnection[]) {
   const visited = new Set([seedId]);
@@ -179,7 +195,20 @@ function buildPromptGalleryCanvasPrompt(referenceImageCount: number) {
 }
 
 function storedToMetadata(stored: UploadedImage | CanvasGeneratedImage, extra?: Partial<CanvasNodeMetadata>): CanvasNodeMetadata {
-  return { status: "success", content: stored.url, storageKey: stored.storageKey, mimeType: stored.mimeType, naturalWidth: stored.width, naturalHeight: stored.height, bytes: stored.bytes, ...extra };
+  const generated = "cacheStatus" in stored ? stored : undefined;
+  return {
+    status: "success",
+    content: stored.url,
+    storageKey: stored.storageKey,
+    mimeType: stored.mimeType,
+    naturalWidth: stored.width,
+    naturalHeight: stored.height,
+    bytes: stored.bytes,
+    resultCacheStatus: generated?.cacheStatus,
+    resultRemoteUrl: generated?.remoteUrl,
+    resultCacheError: generated?.cacheError,
+    ...extra,
+  };
 }
 
 async function importPromptGalleryImage(url: string, promptContent: string) {
@@ -295,6 +324,7 @@ export function CanvasEditor({ projectId, onBack, onRequireApiKey, showToast, sh
   const gestureActive = useRef(false);
   const clipboard = useRef<{ nodes: CanvasNodeData[]; connections: CanvasConnection[] }>({ nodes: [], connections: [] });
   const activeGenerationsRef = useRef<Map<string, AbortController>>(new Map());
+  const resultCacheRetriesRef = useRef<Map<string, AbortController>>(new Map());
   const retryCooldownRef = useRef<Map<string, number>>(new Map());
   const textGenerationControllersRef = useRef<Map<string, AbortController>>(new Map());
   const [undoStack, setUndoStack] = useState<HistorySnapshot[]>([]);
@@ -928,6 +958,21 @@ export function CanvasEditor({ projectId, onBack, onRequireApiKey, showToast, sh
     [nodes, onRequireApiKey, setBusy],
   );
 
+  const applyGeneratedImage = useCallback((nodeId: string, image: CanvasGeneratedImage, prompt?: string) => {
+    const size = fitNodeSize(image.width, image.height, 360, 360);
+    patchNode(nodeId, (node) => ({
+      ...node,
+      width: size.width,
+      height: size.height,
+      metadata: {
+        ...node.metadata,
+        ...storedToMetadata(image, { prompt: prompt ?? node.metadata?.prompt }),
+        generationTaskId: node.metadata?.generationTaskId,
+        generationStartedAt: node.metadata?.generationStartedAt,
+      },
+    }));
+  }, [patchNode]);
+
   const runGeneration = useCallback(
     async (sourceNode: CanvasNodeData) => {
       const promptText = (sourceNode.metadata?.composerContent ?? sourceNode.metadata?.prompt ?? "").trim();
@@ -1045,11 +1090,10 @@ export function CanvasEditor({ projectId, onBack, onRequireApiKey, showToast, sh
         const result = await checkExistingTask(taskId);
         if (result.status === "completed" && result.images?.length) {
           const image = result.images[0];
-          const size = fitNodeSize(image.width, image.height, 360, 360);
           activeGenerationsRef.current.get(node.id)?.abort();
           activeGenerationsRef.current.delete(node.id);
-          patchNode(node.id, (n) => ({ ...n, width: size.width, height: size.height, metadata: { ...n.metadata, ...storedToMetadata(image, { prompt: n.metadata?.prompt }), generationTaskId: n.metadata?.generationTaskId, generationStartedAt: n.metadata?.generationStartedAt } }));
-          showToast("已取回生成结果", "success");
+          applyGeneratedImage(node.id, image);
+          showToast(image.cacheStatus === "cached" ? "已取回生成结果" : "原图暂时不可用，已保留远端结果并继续自动重试", image.cacheStatus === "cached" ? "success" : "info");
           return;
         }
         if (result.status === "failed" || result.status === "expired") {
@@ -1063,8 +1107,72 @@ export function CanvasEditor({ projectId, onBack, onRequireApiKey, showToast, sh
         showToast("获取进度失败", "error");
       }
     },
-    [patchNode, showToast],
+    [applyGeneratedImage, patchNode, showToast],
   );
+
+  // 已完成任务的图片缓存失败时，在后台按递增间隔继续取回；刷新页面后 pending 节点也会进入这里。
+  useEffect(() => {
+    const pendingNodes = nodes.filter((node) =>
+      node.type === CanvasNodeType.Image
+      && node.metadata?.generationTaskId
+      && node.metadata?.resultCacheStatus === "pending",
+    );
+    const pendingIds = new Set(pendingNodes.map((node) => node.id));
+
+    for (const [nodeId, controller] of resultCacheRetriesRef.current) {
+      if (!pendingIds.has(nodeId)) {
+        controller.abort();
+        resultCacheRetriesRef.current.delete(nodeId);
+      }
+    }
+
+    for (const node of pendingNodes) {
+      if (resultCacheRetriesRef.current.has(node.id)) continue;
+      const taskId = node.metadata!.generationTaskId!;
+      const controller = new AbortController();
+      resultCacheRetriesRef.current.set(node.id, controller);
+
+      void (async () => {
+        try {
+          for (const retryDelay of RESULT_CACHE_RETRY_DELAYS) {
+            await waitForResultCacheRetry(retryDelay, controller.signal);
+            const result = await checkExistingTask(taskId, 1);
+            if (controller.signal.aborted) return;
+            if (result.status === "completed" && result.images?.length) {
+              const image = result.images[0];
+              applyGeneratedImage(node.id, image);
+              if (image.cacheStatus === "cached") return;
+              continue;
+            }
+            if (result.status === "failed" || result.status === "expired") {
+              patchNode(node.id, (current) => ({
+                ...current,
+                metadata: { ...current.metadata, resultCacheStatus: "failed", resultCacheError: result.error || "原图已无法取回" },
+              }));
+              return;
+            }
+          }
+          patchNode(node.id, (current) => ({
+            ...current,
+            metadata: { ...current.metadata, resultCacheStatus: "failed", resultCacheError: current.metadata?.resultCacheError || "自动取回原图失败" },
+          }));
+        } catch (error) {
+          if (controller.signal.aborted) return;
+          patchNode(node.id, (current) => ({
+            ...current,
+            metadata: { ...current.metadata, resultCacheStatus: "failed", resultCacheError: error instanceof Error ? error.message : "自动取回原图失败" },
+          }));
+        } finally {
+          resultCacheRetriesRef.current.delete(node.id);
+        }
+      })();
+    }
+  }, [applyGeneratedImage, nodes, patchNode]);
+
+  useEffect(() => () => {
+    for (const controller of resultCacheRetriesRef.current.values()) controller.abort();
+    resultCacheRetriesRef.current.clear();
+  }, []);
 
   // 刷新页面后恢复进行中的生成任务（检查已有 taskId 的状态）
   useEffect(() => {
@@ -1087,8 +1195,7 @@ export function CanvasEditor({ projectId, onBack, onRequireApiKey, showToast, sh
 
           if (result.status === "completed" && result.images?.length) {
             const image = result.images[0];
-            const size = fitNodeSize(image.width, image.height, 360, 360);
-            patchNode(node.id, (n) => ({ ...n, width: size.width, height: size.height, metadata: { ...n.metadata, ...storedToMetadata(image, { prompt: n.metadata?.prompt }), generationTaskId: n.metadata?.generationTaskId, generationStartedAt: n.metadata?.generationStartedAt } }));
+            applyGeneratedImage(node.id, image);
             return;
           }
           if (result.status === "failed" || result.status === "expired") {
@@ -1098,18 +1205,13 @@ export function CanvasEditor({ projectId, onBack, onRequireApiKey, showToast, sh
 
           // 仍在进行中 → 继续轮询
           patchNode(node.id, (n) => ({ ...n, metadata: { ...n.metadata, status: result.status as CanvasNodeMetadata["status"] } }));
-          await pollNodeTask(taskId, (taskStatus) => {
+          const images = await pollNodeTask(taskId, (taskStatus) => {
             if (controller.signal.aborted) return;
             patchNode(node.id, (n) => ({ ...n, metadata: { ...n.metadata, status: taskStatus as CanvasNodeMetadata["status"] } }));
           }, controller.signal);
 
           if (controller.signal.aborted) return;
-          const finalResult = await checkExistingTask(taskId);
-          if (finalResult.images?.length) {
-            const image = finalResult.images[0];
-            const size = fitNodeSize(image.width, image.height, 360, 360);
-            patchNode(node.id, (n) => ({ ...n, width: size.width, height: size.height, metadata: { ...n.metadata, ...storedToMetadata(image, { prompt: n.metadata?.prompt }), generationTaskId: n.metadata?.generationTaskId, generationStartedAt: n.metadata?.generationStartedAt } }));
-          }
+          if (images[0]) applyGeneratedImage(node.id, images[0]);
         } catch {
           if (controller.signal.aborted) return;
           patchNode(node.id, (n) => ({ ...n, metadata: { ...n.metadata, status: "error", errorDetails: "恢复生成状态失败" } }));

--- a/frontend/src/components/canvas/CanvasEditor.tsx
+++ b/frontend/src/components/canvas/CanvasEditor.tsx
@@ -1115,6 +1115,7 @@ export function CanvasEditor({ projectId, onBack, onRequireApiKey, showToast, sh
     const pendingNodes = nodes.filter((node) =>
       node.type === CanvasNodeType.Image
       && node.metadata?.generationTaskId
+      && node.metadata?.status === "success"
       && node.metadata?.resultCacheStatus === "pending",
     );
     const pendingIds = new Set(pendingNodes.map((node) => node.id));

--- a/frontend/src/components/canvas/__tests__/CanvasEditor.routes.test.tsx
+++ b/frontend/src/components/canvas/__tests__/CanvasEditor.routes.test.tsx
@@ -7,6 +7,7 @@ import { CanvasNodeType, type CanvasNodeData } from "../types";
 
 const submitNodeGenerationMock = vi.hoisted(() => vi.fn());
 const pollNodeTaskMock = vi.hoisted(() => vi.fn());
+const checkExistingTaskMock = vi.hoisted(() => vi.fn());
 
 vi.mock("../canvas-generation-service", async () => {
   const actual = await vi.importActual<typeof import("../canvas-generation-service")>("../canvas-generation-service");
@@ -14,6 +15,7 @@ vi.mock("../canvas-generation-service", async () => {
     ...actual,
     submitNodeGeneration: submitNodeGenerationMock,
     pollNodeTask: pollNodeTaskMock,
+    checkExistingTask: checkExistingTaskMock,
   };
 });
 
@@ -73,6 +75,7 @@ describe("CanvasEditor prompt routes", () => {
     submitNodeGenerationMock.mockResolvedValue("task-1");
     pollNodeTaskMock.mockReset();
     pollNodeTaskMock.mockResolvedValue([]);
+    checkExistingTaskMock.mockReset().mockResolvedValue({ status: "processing" });
   });
 
   afterEach(() => {
@@ -281,6 +284,79 @@ describe("CanvasEditor prompt routes", () => {
       const resultNode = useCanvasStore.getState().openProject(project.id)?.nodes.find((node) => node.type === CanvasNodeType.Image);
       expect(resultNode?.title).toBe("北京生成配置1 - 结果 1");
     });
+  });
+
+  it("keeps a completed remote result visible while local caching is pending", async () => {
+    const seeded = structuredClone(project);
+    const config = seeded.nodes.find((node) => node.id === "config-1")!;
+    config.metadata = {
+      ...config.metadata,
+      promptRouteSelection: { mode: "route", connectionIds: ["core-concept", "concept-beijing", "beijing-config-1"] },
+    };
+    useCanvasStore.setState({ hydrated: true, projects: [seeded] });
+    pollNodeTaskMock.mockResolvedValue([{
+      url: "/api/nova/images/task-1/0",
+      remoteUrl: "/api/nova/images/task-1/0",
+      width: 1024,
+      height: 1024,
+      mimeType: "image/png",
+      bytes: 0,
+      cacheStatus: "pending",
+      cacheError: "HTTP 503",
+    }]);
+
+    render(<CanvasEditor projectId={project.id} onBack={() => undefined} onRequireApiKey={() => undefined} showToast={() => undefined} />);
+    fireEvent.click(screen.getByRole("button", { name: "生成" }));
+
+    await waitFor(() => {
+      const resultNode = useCanvasStore.getState().openProject(project.id)?.nodes.find((node) => node.type === CanvasNodeType.Image);
+      expect(resultNode?.metadata).toEqual(expect.objectContaining({
+        content: "/api/nova/images/task-1/0",
+        resultRemoteUrl: "/api/nova/images/task-1/0",
+        resultCacheStatus: "pending",
+        resultCacheError: "HTTP 503",
+      }));
+      expect(screen.getByRole("img", { name: "北京生成配置1 - 结果 1" })).toHaveAttribute("src", "/api/nova/images/task-1/0");
+      expect(screen.getByRole("button", { name: "重新获取原图" })).toBeInTheDocument();
+    });
+  });
+
+  it("resumes caching a pending result after the canvas is reopened", async () => {
+    const originalSetTimeout = globalThis.setTimeout;
+    const timeoutSpy = vi.spyOn(globalThis, "setTimeout").mockImplementation(((handler: TimerHandler, timeout?: number, ...args: unknown[]) =>
+      originalSetTimeout(handler, timeout === 15_000 ? 0 : timeout, ...args)) as typeof setTimeout);
+    try {
+      const seeded = structuredClone(project);
+      seeded.nodes.push({
+        id: "result-1",
+        title: "北京结果",
+        type: CanvasNodeType.Image,
+        position: { x: 1200, y: 40 },
+        width: 360,
+        height: 360,
+        metadata: {
+          status: "success",
+          content: "/api/nova/images/task-1/0",
+          generationTaskId: "task-1",
+          resultCacheStatus: "pending",
+          resultRemoteUrl: "/api/nova/images/task-1/0",
+        },
+      });
+      useCanvasStore.setState({ hydrated: true, projects: [seeded] });
+      checkExistingTaskMock.mockResolvedValue({
+        status: "completed",
+        images: [{ storageKey: "image:1", url: "blob:image-1", width: 1024, height: 1024, mimeType: "image/png", bytes: 128, cacheStatus: "cached" }],
+      });
+
+      render(<CanvasEditor projectId={project.id} onBack={() => undefined} onRequireApiKey={() => undefined} showToast={() => undefined} />);
+      await waitFor(() => {
+        const resultNode = useCanvasStore.getState().openProject(project.id)?.nodes.find((node) => node.id === "result-1");
+        expect(checkExistingTaskMock).toHaveBeenCalledWith("task-1", 1);
+        expect(resultNode?.metadata).toEqual(expect.objectContaining({ storageKey: "image:1", resultCacheStatus: "cached" }));
+      });
+    } finally {
+      timeoutSpy.mockRestore();
+    }
   });
 
   it("previews the final prompt before generation", async () => {

--- a/frontend/src/components/canvas/__tests__/canvas-generation-service.test.ts
+++ b/frontend/src/components/canvas/__tests__/canvas-generation-service.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const getNovaTaskMock = vi.hoisted(() => vi.fn());
+const ackNovaTaskMock = vi.hoisted(() => vi.fn());
+const uploadImageMock = vi.hoisted(() => vi.fn());
+const fetchImageAsBlobMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/ccode-task-client", () => ({
+  getNovaTask: getNovaTaskMock,
+  ackNovaTask: ackNovaTaskMock,
+}));
+
+vi.mock("../lib/image-storage", () => ({
+  uploadImage: uploadImageMock,
+}));
+
+vi.mock("@/lib/image-downloader", () => ({
+  fetchImageAsBlob: fetchImageAsBlobMock,
+}));
+
+import { pollNodeTask } from "../canvas-generation-service";
+
+const completedTask = {
+  id: "task-1",
+  status: "completed",
+  result: { images: ["URL:/api/nova/images/task-1/0"] },
+};
+
+const storedImage = {
+  storageKey: "image:1",
+  url: "blob:image-1",
+  width: 1024,
+  height: 1024,
+  mimeType: "image/png",
+  bytes: 128,
+};
+
+describe("canvas generation result caching", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    getNovaTaskMock.mockReset().mockResolvedValue(completedTask);
+    ackNovaTaskMock.mockReset().mockResolvedValue(undefined);
+    uploadImageMock.mockReset().mockResolvedValue(storedImage);
+    fetchImageAsBlobMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it("retries a temporarily unavailable completed image before acknowledging the task", async () => {
+    const blob = new Blob(["image"], { type: "image/png" });
+    fetchImageAsBlobMock.mockResolvedValue(blob);
+
+    const result = await pollNodeTask("task-1", vi.fn());
+
+    expect(result).toEqual([expect.objectContaining({ cacheStatus: "cached", storageKey: "image:1", url: "blob:image-1" })]);
+    expect(fetchImageAsBlobMock).toHaveBeenCalledWith("/api/nova/images/task-1/0", 3);
+    expect(uploadImageMock).toHaveBeenCalledWith(blob);
+    expect(ackNovaTaskMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the remote image available and does not acknowledge when local caching exhausts its retries", async () => {
+    fetchImageAsBlobMock.mockRejectedValue(new Error("HTTP 503"));
+
+    const result = await pollNodeTask("task-1", vi.fn());
+
+    expect(result).toEqual([
+      expect.objectContaining({
+        cacheStatus: "pending",
+        remoteUrl: "/api/nova/images/task-1/0",
+        url: "/api/nova/images/task-1/0",
+      }),
+    ]);
+    expect(fetchImageAsBlobMock).toHaveBeenCalledWith("/api/nova/images/task-1/0", 3);
+    expect(ackNovaTaskMock).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/canvas/canvas-generation-service.ts
+++ b/frontend/src/components/canvas/canvas-generation-service.ts
@@ -6,6 +6,7 @@
  * 视频/音频不在范围内；图生图无 mask（队列不支持）。
  */
 import { ackNovaTask, createNovaTask, getNovaTask, resolveImageTaskProvider, type NovaTaskResponse, type NovaTaskStatus, type ImageReference } from "@/lib/ccode-task-client";
+import { fetchImageAsBlob } from "@/lib/image-downloader";
 import { normalizeModel } from "@/lib/model-capabilities";
 import { compressReferenceDataUrl } from "./lib/image-utils";
 import { uploadImage } from "./lib/image-storage";
@@ -15,12 +16,15 @@ import type { ReferenceImage } from "./types-media";
 export type { CanvasGenerationConfig };
 
 export type CanvasGeneratedImage = {
-  storageKey: string;
+  storageKey?: string;
   url: string;
   width: number;
   height: number;
   mimeType: string;
   bytes: number;
+  cacheStatus: "cached" | "pending";
+  remoteUrl?: string;
+  cacheError?: string;
 };
 
 export class CanvasApiKeyMissingError extends Error {
@@ -93,9 +97,8 @@ export async function pollNodeTask(
       if (task.status !== "completed" || images.length === 0) {
         throw new Error(task.error || (task.status === "expired" ? "该任务已超出取回时间" : "生成失败"));
       }
-      const stored = (await Promise.all(images.map(storeResultImage))).filter((item): item is CanvasGeneratedImage => Boolean(item));
-      void ackNovaTask(taskId);
-      if (stored.length === 0) throw new Error("生成结果保存失败");
+      const stored = await Promise.all(images.map((image) => storeResultImage(image)));
+      if (stored.every((item) => item.cacheStatus === "cached")) void ackNovaTask(taskId);
       return stored;
     }
     if (Date.now() > deadline) throw new Error("生成超时，请稍后重试");
@@ -104,11 +107,11 @@ export async function pollNodeTask(
 }
 
 /** 检查已有任务的当前状态（用于刷新页面后恢复进行中的任务）。 */
-export async function checkExistingTask(taskId: string): Promise<{ status: NovaTaskResponse["status"]; images?: CanvasGeneratedImage[]; error?: string }> {
+export async function checkExistingTask(taskId: string, maxDownloadRetries = 3): Promise<{ status: NovaTaskResponse["status"]; images?: CanvasGeneratedImage[]; error?: string }> {
   const task = await getNovaTask(taskId);
   if (task.status === "completed" && task.result?.images?.length) {
-    const stored = (await Promise.all(task.result.images.map(storeResultImage))).filter((item): item is CanvasGeneratedImage => Boolean(item));
-    void ackNovaTask(taskId);
+    const stored = await Promise.all(task.result.images.map((image) => storeResultImage(image, maxDownloadRetries)));
+    if (stored.every((item) => item.cacheStatus === "cached")) void ackNovaTask(taskId);
     return { status: "completed", images: stored };
   }
   if (task.status === "failed" || task.status === "expired") {
@@ -156,14 +159,32 @@ export async function generateCanvasImages(args: {
 }
 
 /** 结果可能是 data URL 或 `URL:/api/nova/images/...`；统一下载为 blob 存入本地 IndexedDB。 */
-async function storeResultImage(image: string): Promise<CanvasGeneratedImage | null> {
+async function storeResultImage(image: string, maxDownloadRetries = 3): Promise<CanvasGeneratedImage> {
   const realUrl = image.startsWith("URL:") ? image.slice(4) : image;
-  if (!realUrl) return null;
+  if (!realUrl) throw new Error("生成结果地址为空");
   try {
-    const stored = await uploadImage(realUrl);
-    return { storageKey: stored.storageKey, url: stored.url, width: stored.width, height: stored.height, mimeType: stored.mimeType, bytes: stored.bytes };
-  } catch {
-    return null;
+    const blob = await fetchImageAsBlob(realUrl, maxDownloadRetries);
+    const stored = await uploadImage(blob);
+    return {
+      storageKey: stored.storageKey,
+      url: stored.url,
+      width: stored.width,
+      height: stored.height,
+      mimeType: stored.mimeType,
+      bytes: stored.bytes,
+      cacheStatus: "cached",
+    };
+  } catch (error) {
+    return {
+      url: realUrl,
+      remoteUrl: realUrl,
+      width: 1024,
+      height: 1024,
+      mimeType: "image/png",
+      bytes: 0,
+      cacheStatus: "pending",
+      cacheError: error instanceof Error ? error.message : String(error),
+    };
   }
 }
 

--- a/frontend/src/components/canvas/components/canvas-node.tsx
+++ b/frontend/src/components/canvas/components/canvas-node.tsx
@@ -249,6 +249,7 @@ function ImageNodeBody({
   onRefreshProgress?: (node: CanvasNodeData) => void | Promise<void>;
   onOpenImage?: (node: CanvasNodeData) => void;
 }) {
+  const [refreshingCache, setRefreshingCache] = useState(false);
   const fallbackContent = data.metadata?.content;
   // 不渲染刷新后失效的 blob: URL（避免 ERR_FILE_NOT_FOUND）；由上层 imageUrl（storageKey 解析）提供有效地址
   const url = imageUrl || (fallbackContent && !fallbackContent.startsWith("blob:") ? fallbackContent : undefined);
@@ -304,6 +305,24 @@ function ImageNodeBody({
         >
           <Save className="size-3.5" />
           存素材
+        </button>
+      )}
+
+      {url && !isGenerating && data.metadata?.generationTaskId && (data.metadata?.resultCacheStatus === "pending" || data.metadata?.resultCacheStatus === "failed") && onRefreshProgress && (
+        <button
+          type="button"
+          data-canvas-no-zoom
+          aria-label="重新获取原图"
+          title={data.metadata?.resultCacheError || "重新获取并保存原图"}
+          disabled={refreshingCache}
+          className="absolute right-1.5 bottom-1.5 grid size-7 place-items-center rounded-md bg-amber-600/90 text-white shadow-sm transition-colors hover:bg-amber-700 disabled:cursor-not-allowed disabled:opacity-60"
+          onPointerDown={(event) => event.stopPropagation()}
+          onClick={() => {
+            setRefreshingCache(true);
+            void Promise.resolve(onRefreshProgress(data)).finally(() => setRefreshingCache(false));
+          }}
+        >
+          <RefreshCw className={cn("size-3.5", refreshingCache && "animate-spin")} />
         </button>
       )}
 

--- a/frontend/src/components/canvas/types.ts
+++ b/frontend/src/components/canvas/types.ts
@@ -68,6 +68,12 @@ export type CanvasNodeMetadata = {
   storageKey?: string;
   mimeType?: string;
   bytes?: number;
+  /** 生成结果是否已经持久化到本地图片存储。 */
+  resultCacheStatus?: "pending" | "cached" | "failed";
+  /** 本地缓存失败时保留的后端图片地址。 */
+  resultRemoteUrl?: string;
+  /** 最近一次缓存失败原因。 */
+  resultCacheError?: string;
   /** 配置节点的逐节点生成参数 */
   genConfig?: CanvasGenerationConfig;
   /** 配置节点：锁定结果节点模式 */


### PR DESCRIPTION
## 变更说明

修复无限画布中生成任务已经完成，但结果图片偶发无法显示的问题。

## 主要改动

- 生成结果图片下载失败时自动重试 3 次
- 本地缓存失败时保留远端图片地址，避免结果节点显示为空
- 仅在图片成功保存到本地后确认任务，延长失败结果的可恢复时间
- 本地缓存失败后按 15 秒、30 秒、60 秒继续后台重试
- 刷新或重新打开画布后，自动恢复尚未完成的图片缓存任务
- 为缓存失败的图片节点增加手动重新获取入口
- 避免任务恢复过程中重复查询已经取得的生成结果
- 增加结果下载、ACK 条件、远端回退和刷新恢复相关测试

## 验证

- 无限画布测试：49 个全部通过
- 前端全量测试：366 个全部通过
- 前端生产构建通过
- `git diff --check` 通过

## 兼容性

不修改后端任务接口和现有画布数据结构的必填字段。已有画布项目可以继续正常打开，新增加的缓存状态字段均为可选字段。